### PR TITLE
[ENH] Ajout d'une abstraction pour retry / error

### DIFF
--- a/src/MerQure.RbMQ/Clients/Publisher.cs
+++ b/src/MerQure.RbMQ/Clients/Publisher.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using System.Text;
 using MerQure.RbMQ.Helpers;
+using MerQure.RbMQ.Content;
 
 namespace MerQure.RbMQ.Clients
 {
@@ -29,6 +30,10 @@ namespace MerQure.RbMQ.Clients
             this.ExchangeName = exchangeName.ToLowerInvariant();
         }
 
+        public bool PublishWithAcknowledgement(string queueName, string message)
+        {
+            return PublishWithAcknowledgement(new Message(queueName, message));
+        }
 
         public bool PublishWithAcknowledgement(IMessage message)
         {

--- a/src/MerQure.RbMQ/MerQure.RbMQ.csproj
+++ b/src/MerQure.RbMQ/MerQure.RbMQ.csproj
@@ -32,6 +32,9 @@
     <CodeAnalysisRuleSet>MerQure.RbMQ.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\packages\RabbitMQ.Client.4.1.1\lib\net451\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>

--- a/src/MerQure.RbMQ/packages.config
+++ b/src/MerQure.RbMQ/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="4.1.1" targetFramework="net452" />
   <package id="SonarAnalyzer.CSharp" version="1.23.0.1857" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/MerQure.Samples/DeadLetterExample.cs
+++ b/src/MerQure.Samples/DeadLetterExample.cs
@@ -45,7 +45,7 @@ namespace MerQure.Samples
             }
 
             // Get the consumer on the existing queue and consume its messages
-            var consumer = messagingService.GetConsumer("deadletter.queue");
+            var consumer = messagingService.GetOrCreateConsumer("deadletter.queue");
             consumer.Consume((object sender, IMessagingEvent args) =>
             {
                 var realDelay = DateTime.Now.Subtract(dateStart).TotalSeconds;

--- a/src/MerQure.Samples/MerQure.Samples.csproj
+++ b/src/MerQure.Samples/MerQure.Samples.csproj
@@ -50,6 +50,12 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="DeadLetterExample.cs" />
+    <Compile Include="RetryExchange\Domain\ISomethingService.cs" />
+    <Compile Include="RetryExchange\Domain\SampleService.cs" />
+    <Compile Include="RetryExchange\Domain\Something.cs" />
+    <Compile Include="RetryExchange\Domain\SomethingException.cs" />
+    <Compile Include="RetryExchange\Infra\SomethingQueuesName.cs" />
+    <Compile Include="RetryExchange\Infra\SomethingService.cs" />
     <Compile Include="SimpleExample.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StopExample.cs" />

--- a/src/MerQure.Samples/Program.cs
+++ b/src/MerQure.Samples/Program.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using MerQure.Samples.RetryExchange.Domain;
+using MerQure.Samples.RetryExchange.Infra;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -20,6 +22,17 @@ namespace MerQure.Samples
             System.Threading.Thread.Sleep(500);
             Console.WriteLine("Running sample 3: deadletter");
             DeadLetterExample.Run();
+
+            Console.WriteLine("Running sample 4 : retry exchange");
+            ISomethingService somethingService = new SomethingService();
+            var actionService = new SampleService(somethingService);
+            actionService.Consume();
+            for (int i = 0; i < 50; i++)
+            {
+                actionService.SendNewSomething();
+            }
+
+            Console.ReadLine();
         }
     }
 }

--- a/src/MerQure.Samples/RetryExchange/Domain/ISomethingService.cs
+++ b/src/MerQure.Samples/RetryExchange/Domain/ISomethingService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Samples.RetryExchange.Domain
+{
+    public interface ISomethingService
+    {
+        void Send(Something thing);
+        void Consume(EventHandler<Something> onSomethingReceived);
+        void Acknowlegde(Something something);
+        void RetryLater(Something something);
+        void SendOnError(Something something);
+    }
+}

--- a/src/MerQure.Samples/RetryExchange/Domain/SampleService.cs
+++ b/src/MerQure.Samples/RetryExchange/Domain/SampleService.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Samples.RetryExchange.Domain
+{
+    public class SampleService
+    {
+        private static int _fakeError;
+
+        private readonly ISomethingService _somethingService;
+
+        public SampleService(ISomethingService somethingService)
+        {
+            _somethingService = somethingService;
+        }
+
+        public void SendNewSomething()
+        {
+            _somethingService.Send(new Something()
+            {
+                Name = "MerQure"
+            });
+        }
+
+        public void Consume()
+        {
+            _somethingService.Consume(async (object sender, Something something) => await OnSomethingReceived(sender, something));
+        }
+
+        public async Task OnSomethingReceived(object sender, Something something)
+        {
+            try
+            {
+                await ManageNewSomething(something);
+            }
+            catch (SomethingException)
+            {
+                _somethingService.RetryLater(something);
+            }
+            catch (Exception e)
+            {
+                _somethingService.SendOnError(something);
+                //...
+            }
+        }
+
+        private async Task ManageNewSomething(Something something)
+        {
+            _fakeError++;
+
+            int value = new Random().Next(1000, 3000);
+            await Task.Delay(value);
+            if (_fakeError % 15 == 0)
+            {
+                throw new Exception("This is an unmanageable exception, like NPE");
+            }
+            else if (_fakeError % 5 == 0)
+            {
+                throw new SomethingException("This is an \"retry later\" exception");
+            }
+            else
+            {
+                //everything ok
+                _somethingService.Acknowlegde(something);
+            }
+        }
+    }
+}

--- a/src/MerQure.Samples/RetryExchange/Domain/Something.cs
+++ b/src/MerQure.Samples/RetryExchange/Domain/Something.cs
@@ -1,0 +1,15 @@
+﻿using MerQure.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Samples.RetryExchange.Domain
+{
+    public class Something : IAmqpIdentity
+    {
+        public string DeliveryTag { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/MerQure.Samples/RetryExchange/Domain/SomethingException.cs
+++ b/src/MerQure.Samples/RetryExchange/Domain/SomethingException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Samples.RetryExchange.Domain
+{
+    public class SomethingException : Exception
+    {
+        public SomethingException()
+        {
+        }
+
+        public SomethingException(string message)
+        : base(message)
+        {
+        }
+
+        public SomethingException(string message, Exception inner)
+        : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/MerQure.Samples/RetryExchange/Infra/SomethingQueuesName.cs
+++ b/src/MerQure.Samples/RetryExchange/Infra/SomethingQueuesName.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Samples.RetryExchange.Infra
+{
+    public static class SomethingQueuesName
+    {
+        public const string MessageSended = "v1.something.messagesended";
+        public const string OtherAction = "v1.something.otheraction";
+
+        public static List<string> GetAll()
+        {
+            return new List<string>()
+            {
+                {MessageSended },
+                {OtherAction }
+            };
+        }
+    }
+}

--- a/src/MerQure.Samples/RetryExchange/Infra/SomethingService.cs
+++ b/src/MerQure.Samples/RetryExchange/Infra/SomethingService.cs
@@ -1,0 +1,63 @@
+﻿using MerQure.Configuration;
+using MerQure.RbMQ;
+using MerQure.Samples.RetryExchange.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Samples.RetryExchange.Infra
+{
+    public class SomethingService : ISomethingService
+    {
+        public const string ExchangeName = "something";
+        public IRetryExchange<Something> SomethingExchange { get; set; }
+
+        public SomethingService()
+        {
+            var somethingConfiguration = new RetryExchangeConfiguration()
+            {
+                QueuesName = SomethingQueuesName.GetAll(),
+                ExchangeName = ExchangeName,
+                DelaysInMillisecondsBetweenEachRetry = new List<int>
+                    {
+                        {6000 },
+                        {10000 },
+                        {100000 }
+                    },
+                EndOnErrorExchange = true
+            };
+            IMessagingService messagingService = new MessagingService();
+            SomethingExchange = new RetryExchangeService(messagingService).Get<Something>(somethingConfiguration);
+        }
+
+        public void Send(Something something)
+        {
+            SomethingExchange.Publish(SomethingQueuesName.MessageSended, something);
+        }
+
+        public void Consume(EventHandler<Something> callback)
+        {
+            SomethingExchange.Consume(SomethingQueuesName.MessageSended, (object sender, Something something) =>
+            {
+                callback(this, something);
+            });
+        }
+
+        public void RetryLater(Something something)
+        {
+            SomethingExchange.ApplyRetryStrategy(SomethingQueuesName.MessageSended, something);
+        }
+
+        public void Acknowlegde(Something something)
+        {
+            SomethingExchange.AcknowlegdeDelivredMessage(SomethingQueuesName.MessageSended, something);
+        }
+
+        public void SendOnError(Something something)
+        {
+            SomethingExchange.SendDelivredMessageToErrorExchange(SomethingQueuesName.MessageSended, something);
+        }
+    }
+}

--- a/src/MerQure.Samples/SimpleExample.cs
+++ b/src/MerQure.Samples/SimpleExample.cs
@@ -28,7 +28,7 @@ namespace MerQure.Samples
 
 
             // Get the consumer on the existing queue and consume its messages
-            var consumer = messagingService.GetConsumer("simple.queue");
+            var consumer = messagingService.GetOrCreateConsumer("simple.queue");
             var random = new Random();
             consumer.Consume((object sender, IMessagingEvent args) =>
             {

--- a/src/MerQure.Samples/StopExample.cs
+++ b/src/MerQure.Samples/StopExample.cs
@@ -27,7 +27,7 @@ namespace MerQure.Samples
             }
 
             // Get the consumer on the existing queue and consume its messages
-            var consumer = messagingService.GetConsumer("stop.queue");
+            var consumer = messagingService.GetOrCreateConsumer("stop.queue");
             consumer.Consume((object sender, IMessagingEvent args) =>
             {
                 Console.WriteLine("Consumer Working: " + consumer.IsConsuming());

--- a/src/MerQure.Samples/rabbitMQ.config
+++ b/src/MerQure.Samples/rabbitMQ.config
@@ -1,6 +1,7 @@
 ﻿<rabbitMQ 
   durable="true" 
-  autoDeleteQueue="false">
+  autoDeleteQueue="false"
+  defaultPrefetchCount="10">
   
   <connection 
     connectionString="amqp://guest:guest@localhost:5672/" 

--- a/src/MerQure/Clients/IPublisher.cs
+++ b/src/MerQure/Clients/IPublisher.cs
@@ -26,5 +26,15 @@ namespace MerQure
         /// <param name="message">message</param>
         /// <see cref="http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/"/>
         bool PublishWithAcknowledgement(IMessage message);
+
+        /// <summary>
+        /// Publishes a message with broker confirmation.
+        /// Waits until all messages published since the last call have been confirmed. Default timeout is 10000 milliseconds. 
+        /// Set the publisherAcknowledgementsTimeoutInMilliseconds attribute in RabbitMQ.config to change it.
+        /// </summary>
+        /// <param name="queueName">queue name</param>
+        /// <param name="message">message</param>
+        /// <see cref="http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/"/>
+        bool PublishWithAcknowledgement(string queueName, string message);
     }
 }

--- a/src/MerQure/Configuration/RetryExchangeConfiguration.cs
+++ b/src/MerQure/Configuration/RetryExchangeConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Configuration
+{
+    public class RetryExchangeConfiguration
+    {
+        public RetryExchangeConfiguration()
+        {
+            DelaysInMillisecondsBetweenEachRetry = new List<int>();
+        }
+
+        public string ExchangeName { get; set; }
+        public List<string> QueuesName { get; set; }
+
+        /// <summary>
+        /// Empty list => 0 retry 
+        /// 
+        /// </summary>
+        public List<int> DelaysInMillisecondsBetweenEachRetry { get; set; }
+
+        public bool EndOnErrorExchange { get; set; }
+    }
+}

--- a/src/MerQure/Content/IAmqpIdentity.cs
+++ b/src/MerQure/Content/IAmqpIdentity.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Content
+{
+    public interface IAmqpIdentity
+    {
+        string DeliveryTag { get; set; }
+    }
+}

--- a/src/MerQure/Exceptions/MerQureException.cs
+++ b/src/MerQure/Exceptions/MerQureException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.Exceptions
+{
+    public class MerQureException : Exception
+    {
+        public MerQureException()
+        {
+        }
+
+        public MerQureException(string message)
+        : base(message)
+        {
+        }
+
+        public MerQureException(string message, Exception inner)
+        : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/MerQure/IMessagingService.cs
+++ b/src/MerQure/IMessagingService.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using MerQure.Configuration;
+using MerQure.Content;
+using System.Collections.Generic;
 
 namespace MerQure
 {
@@ -85,17 +87,30 @@ namespace MerQure
         IPublisher GetPublisher(string exchangeName, bool enablePublisherAcknowledgements);
 
         /// <summary>
-        /// Get the consumer, used to receive messages of a queue
+        /// Get the consumer or create if it is not existing, used to receive messages of a queue
         /// </summary>
         /// <param name="queueName"></param>
-        IConsumer GetConsumer(string queueName);
+        IConsumer GetOrCreateConsumer(string queueName);
 
         /// <summary>
-        /// Get the consumer, used to receive messages of a queue
+        /// Get the consumer or create if it is not existing, used to receive messages of a queue
         /// </summary>
         /// <param name="queueName"></param>
         /// <param name="prefetchCount">maximum number of messages that the server will deliver, 0 if unlimited</param>
         /// <returns></returns>
-        IConsumer GetConsumer(string queueName, ushort prefetchCount);
+        IConsumer GetOrCreateConsumer(string queueName, ushort prefetchCount);
+
+        /// <summary>
+        /// Create a new consumer, used to receive messages of a queue
+        /// </summary>
+        /// <param name="queueName"></param>
+        IConsumer CreateConsumer(string queueName);
+
+        /// <summary>
+        /// Create a new consumer, used to receive messages of a queue
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <param name="prefetchCount">maximum number of messages that the server will deliver, 0 if unlimited</param>
+        IConsumer CreateConsumer(string queueName, ushort prefetchCount);
     }
 }

--- a/src/MerQure/IRetryExchange.cs
+++ b/src/MerQure/IRetryExchange.cs
@@ -1,0 +1,20 @@
+﻿using MerQure.Configuration;
+using MerQure.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure
+{
+    public interface IRetryExchange<T> where T : IAmqpIdentity
+    {
+        void Publish(string queueName, T message);
+        void Consume(string queueName, EventHandler<T> callback);
+        void ApplyRetryStrategy(string queueName, T message);
+        void AcknowlegdeDelivredMessage(string queueName, T delivredMessage);
+        void RejectDeliveredMessage(string queueName, T delivredMessage);
+        void SendDelivredMessageToErrorExchange(string queueName, T delivredMessage);
+    }
+}

--- a/src/MerQure/IRetryExchangeService.cs
+++ b/src/MerQure/IRetryExchangeService.cs
@@ -1,0 +1,15 @@
+﻿using MerQure.Configuration;
+using MerQure.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure
+{
+    public interface IRetryExchangeService
+    {
+        IRetryExchange<T> Get<T>(RetryExchangeConfiguration retryExchangeConfiguration) where T : IAmqpIdentity;
+    }
+}

--- a/src/MerQure/MerQure.csproj
+++ b/src/MerQure/MerQure.csproj
@@ -35,6 +35,9 @@
     <CodeAnalysisRuleSet>MerQure.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -46,13 +49,24 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Clients\IConsumer.cs" />
+    <Compile Include="Configuration\RetryExchangeConfiguration.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Content\IAmqpIdentity.cs" />
     <Compile Include="Content\IHeader.cs" />
     <Compile Include="Content\IMessage.cs" />
     <Compile Include="Events\IMessagingEvent.cs" />
+    <Compile Include="Exceptions\MerQureException.cs" />
+    <Compile Include="IRetryExchange.cs" />
     <Compile Include="IMessagingService.cs" />
     <Compile Include="Clients\IPublisher.cs" />
+    <Compile Include="IRetryExchangeService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RetryExchangeService.cs" />
+    <Compile Include="RetryExchange\EncapsuledMessage.cs" />
+    <Compile Include="RetryExchange\MessageTechnicalInformations.cs" />
+    <Compile Include="RetryExchange\RetryConsumer.cs" />
+    <Compile Include="RetryExchange\RetryExchange.cs" />
+    <Compile Include="RetryExchange\RetryPublisher.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="CHANGELOG.md" />
@@ -64,6 +78,7 @@
     <Analyzer Include="..\packages\SonarAnalyzer.CSharp.1.23.0.1857\analyzers\SonarAnalyzer.CSharp.dll" />
     <Analyzer Include="..\packages\SonarAnalyzer.CSharp.1.23.0.1857\analyzers\SonarAnalyzer.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/MerQure/RetryExchange/EncapsuledMessage.cs
+++ b/src/MerQure/RetryExchange/EncapsuledMessage.cs
@@ -1,0 +1,15 @@
+﻿using MerQure.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.RetryExchange
+{
+    internal class EncapsuledMessage<T> where T : IAmqpIdentity
+    {
+        public MessageTechnicalInformations TechnicalInformation { get; set; }
+        public T OriginalMessage { get; set; }
+    }
+}

--- a/src/MerQure/RetryExchange/MessageTechnicalInformations.cs
+++ b/src/MerQure/RetryExchange/MessageTechnicalInformations.cs
@@ -1,0 +1,7 @@
+﻿namespace MerQure.RetryExchange
+{
+    internal class MessageTechnicalInformations
+    {
+        public int NumberOfRetry { get; set; }
+    }
+}

--- a/src/MerQure/RetryExchange/RetryConsumer.cs
+++ b/src/MerQure/RetryExchange/RetryConsumer.cs
@@ -1,0 +1,100 @@
+﻿using MerQure.Configuration;
+using MerQure.Content;
+using MerQure.Exceptions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.RetryExchange
+{
+    internal class RetryConsumer<T> where T : IAmqpIdentity
+    {
+        private readonly IMessagingService _messagingService;
+        private readonly RetryPublisher<T> _producer;
+        private readonly RetryExchangeConfiguration _exchangeConfiguration;
+
+        private Dictionary<string, MessageTechnicalInformations> _technicalInformations;
+
+        public RetryConsumer(IMessagingService messagingService, RetryExchangeConfiguration exchangeConfiguration, RetryPublisher<T> publisher)
+        {
+            _messagingService = messagingService;
+            _exchangeConfiguration = exchangeConfiguration;
+            _producer = publisher;
+            _technicalInformations = new Dictionary<string, MessageTechnicalInformations>();
+        }
+
+        public void Consume(string queueName, EventHandler<T> callback)
+        {
+            _messagingService.GetOrCreateConsumer(queueName).Consume((object sender, IMessagingEvent messagingEvent) =>
+            {
+                EncapsuledMessage<T> deserializedMessage = JsonConvert.DeserializeObject<EncapsuledMessage<T>>(messagingEvent.Message.GetBody());
+                deserializedMessage.OriginalMessage.DeliveryTag = messagingEvent.DeliveryTag;
+                _technicalInformations.Add(messagingEvent.DeliveryTag, deserializedMessage.TechnicalInformation);
+
+                callback(this, deserializedMessage.OriginalMessage);
+            });
+        }
+
+        public void SendToErrorExchange(string queueName, T delivredMessage)
+        {
+            if (String.IsNullOrEmpty(delivredMessage.DeliveryTag))
+                throw new ArgumentNullException(nameof(delivredMessage.DeliveryTag));
+            if (!_technicalInformations.ContainsKey(delivredMessage.DeliveryTag))
+                throw new MerQureException($"unknown delivery tag {delivredMessage.DeliveryTag}");
+
+            MessageTechnicalInformations technicalInformations = _technicalInformations[delivredMessage.DeliveryTag];
+
+            _producer.PublishOnErrorExchange(queueName, delivredMessage, technicalInformations);
+            AcknowlegdeDelivredMessage(queueName, delivredMessage);
+            _technicalInformations.Remove(delivredMessage.DeliveryTag);
+        }
+
+        public void ApplyRetryStrategy(string queueName, T delivredMessage)
+        {
+            if (String.IsNullOrEmpty(delivredMessage.DeliveryTag))
+                throw new ArgumentNullException(nameof(delivredMessage.DeliveryTag));
+            if (!_technicalInformations.ContainsKey(delivredMessage.DeliveryTag))
+                throw new MerQureException($"unknown delivery tag {delivredMessage.DeliveryTag}");
+
+            MessageTechnicalInformations technicalInformations = _technicalInformations[delivredMessage.DeliveryTag];
+
+            if (IsGoingToErrorExchange(technicalInformations))
+            {
+                _producer.PublishOnErrorExchange(queueName, delivredMessage, technicalInformations);
+            }
+            else
+            {
+                _producer.PublishOnRetryExchange(queueName, delivredMessage, technicalInformations);
+            }
+            AcknowlegdeDelivredMessage(queueName, delivredMessage);
+            _technicalInformations.Remove(delivredMessage.DeliveryTag);
+        }
+
+        private bool IsGoingToErrorExchange(MessageTechnicalInformations technicalInformations)
+        {
+            if (!_exchangeConfiguration.DelaysInMillisecondsBetweenEachRetry.Any())
+            {
+                return true;
+            }
+            if (_exchangeConfiguration.EndOnErrorExchange
+                   && technicalInformations.NumberOfRetry == _exchangeConfiguration.DelaysInMillisecondsBetweenEachRetry.Count)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        internal void AcknowlegdeDelivredMessage(string queueName, IAmqpIdentity delivredMessage)
+        {
+            _messagingService.GetOrCreateConsumer(queueName).AcknowlegdeDeliveredMessage(delivredMessage.DeliveryTag);
+        }
+
+        internal void RejectDeliveredMessage(string queueName, IAmqpIdentity delivredMessage)
+        {
+            _messagingService.GetOrCreateConsumer(queueName).RejectDeliveredMessage(delivredMessage.DeliveryTag);
+        }
+    }
+}

--- a/src/MerQure/RetryExchange/RetryExchange.cs
+++ b/src/MerQure/RetryExchange/RetryExchange.cs
@@ -1,0 +1,51 @@
+﻿using MerQure.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.RetryExchange
+{
+    internal class RetryExchange<T> : IRetryExchange<T> where T : IAmqpIdentity
+    {
+        internal RetryPublisher<T> Publisher { get; set; }
+        internal RetryConsumer<T> Consumer { get; set; }
+
+        internal RetryExchange(RetryPublisher<T> producer, RetryConsumer<T> consumer)
+        {
+            Publisher = producer;
+            Consumer = consumer;
+        }
+
+        public void AcknowlegdeDelivredMessage(string queueName, T delivredMessage)
+        {
+            Consumer.AcknowlegdeDelivredMessage(queueName, delivredMessage);
+        }
+
+        public void Consume(string queueName, EventHandler<T> callback)
+        {
+            Consumer.Consume(queueName, callback);
+        }
+
+        public void Publish(string queueName, T message)
+        {
+            Publisher.Publish(queueName, message);
+        }
+
+        public void RejectDeliveredMessage(string queueName, T delivredMessage)
+        {
+            Consumer.RejectDeliveredMessage(queueName, delivredMessage);
+        }
+
+        public void ApplyRetryStrategy(string queueName, T delivredMessage)
+        {
+            Consumer.ApplyRetryStrategy(queueName, delivredMessage);
+        }
+
+        public void SendDelivredMessageToErrorExchange(string queueName, T delivredMessage)
+        {
+            Consumer.SendToErrorExchange(queueName, delivredMessage);
+        }
+    }
+}

--- a/src/MerQure/RetryExchange/RetryPublisher.cs
+++ b/src/MerQure/RetryExchange/RetryPublisher.cs
@@ -1,0 +1,91 @@
+﻿using MerQure.Configuration;
+using MerQure.Content;
+using MerQure.Exceptions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.RetryExchange
+{
+    internal class RetryPublisher<T> where T : IAmqpIdentity
+    {
+
+        private readonly RetryExchangeConfiguration _retryExchangeConfiguration;
+        private readonly IMessagingService _messagingService;
+
+        public RetryPublisher(IMessagingService messagingService, RetryExchangeConfiguration messageBrokerConfiguration)
+        {
+            _retryExchangeConfiguration = messageBrokerConfiguration;
+            _messagingService = messagingService;
+        }
+
+
+        public void Publish(string queueName, T message)
+        {
+            using (var publisher = _messagingService.GetPublisher(_retryExchangeConfiguration.ExchangeName, true))
+            {
+                var encapsuledMessage = new EncapsuledMessage<T>
+                {
+                    TechnicalInformation = new MessageTechnicalInformations
+                    {
+                        NumberOfRetry = 0
+                    },
+                    OriginalMessage = message
+                };
+                TryPublishWithBrokerAcknowledgement(publisher, queueName, JsonConvert.SerializeObject(encapsuledMessage));
+            }
+        }
+
+        public void PublishOnRetryExchange(string queueName, T message, MessageTechnicalInformations technicalInformations)
+        {
+            technicalInformations.NumberOfRetry++;
+            EncapsuledMessage<T> encapsuledMessage = new EncapsuledMessage<T>
+            {
+                OriginalMessage = message,
+                TechnicalInformation = technicalInformations
+            };
+            List<int> delays = _retryExchangeConfiguration.DelaysInMillisecondsBetweenEachRetry;
+            int delay;
+            if (delays.Count >= technicalInformations.NumberOfRetry)
+            {
+                delay = delays[technicalInformations.NumberOfRetry - 1];
+            }
+            else
+            {
+                delay = delays.Last();
+            }
+
+            string queueRenamed = $"{queueName}.{delay}";
+            using (var publisher = _messagingService.GetPublisher($"{_retryExchangeConfiguration.ExchangeName}.retry", true))
+            {
+                TryPublishWithBrokerAcknowledgement(publisher, queueRenamed, JsonConvert.SerializeObject(encapsuledMessage));
+            }
+        }
+
+        public void PublishOnErrorExchange(string queueName, T message, MessageTechnicalInformations technicalInformations)
+        {
+            EncapsuledMessage<T> encapsuledMessage = new EncapsuledMessage<T>
+            {
+                OriginalMessage = message,
+                TechnicalInformation = technicalInformations
+            };
+            string queueRenamed = $"{queueName}.error";
+            using (var publisher = _messagingService.GetPublisher($"{_retryExchangeConfiguration.ExchangeName}.error", true))
+            {
+                TryPublishWithBrokerAcknowledgement(publisher, queueRenamed, JsonConvert.SerializeObject(encapsuledMessage));
+            }
+        }
+
+        public void TryPublishWithBrokerAcknowledgement(IPublisher publisher, string queueName, string message)
+        {
+            bool published = publisher.PublishWithAcknowledgement(queueName, message);
+            if (!published)
+            {
+                throw new MerQureException($"unable to send message to the broker. {Environment.NewLine}Channel : {queueName}{Environment.NewLine}Message : {message}");
+            }
+        }
+    }
+}

--- a/src/MerQure/RetryExchangeService.cs
+++ b/src/MerQure/RetryExchangeService.cs
@@ -1,0 +1,81 @@
+﻿using MerQure.Configuration;
+using MerQure.Content;
+using MerQure.RetryExchange;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MerQure.RbMQ
+{
+    public class RetryExchangeService : IRetryExchangeService
+    {
+        private readonly IMessagingService _messagingService;
+
+        public RetryExchangeService(IMessagingService messagingService)
+        {
+            _messagingService = messagingService;
+        }
+
+        public IRetryExchange<T> Get<T>(RetryExchangeConfiguration configuration) where T : IAmqpIdentity
+        {
+            ApplyNewConfiguration(configuration);
+
+            RetryPublisher<T> publisher = new RetryPublisher<T>(_messagingService, configuration);
+            RetryConsumer<T> consumer = new RetryConsumer<T>(_messagingService, configuration, publisher);
+
+            return new RetryExchange<T>(publisher, consumer);
+        }
+
+        private void ApplyNewConfiguration(RetryExchangeConfiguration configuration)
+        {
+            if (configuration.QueuesName == null || !configuration.QueuesName.Any())
+                throw new ArgumentNullException(nameof(configuration.QueuesName));
+
+            CreateMainExchange(configuration);
+            CreateRetryExchangeIfNecessary(configuration);
+            CreateErrorExchange(configuration);
+        }
+
+        private void CreateErrorExchange(RetryExchangeConfiguration configuration)
+        {
+            string errorExchangeName = $"{configuration.ExchangeName}.error";
+            _messagingService.DeclareExchange(errorExchangeName, Constants.ExchangeTypeDirect);
+            foreach (string queueName in configuration.QueuesName)
+            {
+                string errorQueueName = $"{queueName}.error";
+                _messagingService.DeclareQueue(errorQueueName);
+                _messagingService.DeclareBinding(errorExchangeName, errorQueueName, errorQueueName);
+            }
+        }
+
+        private void CreateRetryExchangeIfNecessary(RetryExchangeConfiguration configuration)
+        {
+            if (configuration.DelaysInMillisecondsBetweenEachRetry.Any())
+            {
+                string retryExchangeName = $"{configuration.ExchangeName}.retry";
+                _messagingService.DeclareExchange(retryExchangeName, Constants.ExchangeTypeDirect);
+                foreach (int delay in configuration.DelaysInMillisecondsBetweenEachRetry)
+                {
+                    foreach (string queueName in configuration.QueuesName)
+                    {
+                        string retryQueueName = $"{queueName}.{delay}";
+                        _messagingService.DeclareQueueWithDeadLetterPolicy(retryQueueName, configuration.ExchangeName, delay, null);
+                        _messagingService.DeclareBinding(retryExchangeName, retryQueueName, $"{queueName}.{delay}", null);
+                    }
+                }
+            }
+        }
+
+        private void CreateMainExchange(RetryExchangeConfiguration configuration)
+        {
+            _messagingService.DeclareExchange(configuration.ExchangeName, Constants.ExchangeTypeTopic);
+            foreach (string queueName in configuration.QueuesName)
+            {
+                _messagingService.DeclareQueue(queueName);
+                _messagingService.DeclareBinding(configuration.ExchangeName, queueName, $"{queueName}.#");
+            }
+        }
+    }
+}

--- a/src/MerQure/packages.config
+++ b/src/MerQure/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="SonarAnalyzer.CSharp" version="1.23.0.1857" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Il y a pas mal de choses perfectibles, l'idée est d'abord d'en discuter globalement 

----------

Permet de mettre simplement en place ce cas d'usage :

1) traiter X messages en parallèle avec un même consummer
2) lors du traitement d'un message, si le traitement n'a pas pu être effectué, le message peut être renvoyé dans un exchange de temporisation avant de revenir à l'étape 1.
3) possibilité de créer X queue de tempo (5min, 1h, 24h...) puis à chaque echec le message est renvoyé dans une queue plus longue
4) possibilité d'envoyer un message reçu dans un exchange d'erreur pour le conserver / tracer
5) possibilité d'avoir le message qui part dans l'exchange des erreurs une fois toutes les temporisations consommées

--

/!\ breaking change sur la gestion des consumer (modification du get())