### PR TITLE
[ADD] ajout de config pour le versionning & build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,7 @@ after_build:
 - dotnet sonarscanner end /d:"sonar.login=%SONAR_TOKEN%"
 - ps: dotnet pack src\MerQure\MerQure.csproj --configuration Release /p:PackageVersion=$env:APPVEYOR_BUILD_VERSION -o ..\..\artifacts
 - ps: dotnet pack src\MerQure.RbMQ\MerQure.RbMQ.csproj --configuration Release /p:PackageVersion=$env:APPVEYOR_BUILD_VERSION -o ..\..\artifacts
+- ps: dotnet pack src\MerQure.Tools\MerQure.Tools.csproj --configuration Release /p:PackageVersion=$env:APPVEYOR_BUILD_VERSION -o ..\..\artifacts
 
 test_script:
 - OpenCover.4.6.519\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test /p:DebugType=full -c Debug .\tests\MerQure.RbMQ.Tests\MerQure.RbMQ.Tests.csproj" -filter:"+[MerQure*]* -[MerQure.RbMQ.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -output:coverage-opencover.xml

--- a/build_local.ps1
+++ b/build_local.ps1
@@ -16,5 +16,4 @@ param(
     dotnet build .\MerQure.sln $props
     dotnet pack .\src\MerQure\MerQure.csproj --configuration Debug $propack -o $nuget_path
     dotnet pack .\src\MerQure.RbMQ\MerQure.RbMQ.csproj --configuration Debug $propack -o $nuget_path
- 
-    
+    dotnet pack .\src\MerQure.RbMQ\MerQure.Tools.csproj --configuration Debug $propack -o $nuget_path

--- a/src/MerQure.Tools/MerQure.Tools.csproj
+++ b/src/MerQure.Tools/MerQure.Tools.csproj
@@ -1,7 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+
+    <Company>Lucca SA</Company>
+    <PackageLicenseUrl>https://github.com/LuccaSA/MerQure/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl></PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/LuccaSA/MerQure/master/MerQure-logo.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/LuccaSA/MerQure</RepositoryUrl>
+    <Copyright>Copyright 2017</Copyright>
+    <PackageTags>MessageBroker AMQP RabbitMQ</PackageTags>
+
+    <VersionPrefix>0.0.7</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
+    <PackageVersion>0.0.7</PackageVersion>
+    <Version>0.0.7</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
C'est une PR orienté question, jusque la MerQure.Tools était publié sur notre nuget privé car il n'était pas sur le master de MerQure. 
J'ai juste repris la configuration qui semblait logique pour intégrer MerQure.Tools à master. 

Il reste quoi à faire pour gérer le déploiement auto sur nuget.org ? 
Est-ce que tant qu'on est dans le coin, il faudrait pas mettre Lucca en owner de MerQure et MerQure.Rmq sur nuget.org ? 
Est-ce que ça gère bien le versionning multiple ? (version différente entre merQure et merQure.Tools)

Merci 👍