### PR TITLE
Connection.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2 - 2018-11-21
+### Added
+- 2 new parameters on rabbitMq connection: friendlyName & requestedChannelMax
+
 ## 0.5.1 - 2018-09-25
 ### Fixed
 - SharedConnection is disposable to properly close rabbitMq connection

--- a/samples/MerQure.Samples/MerQure.Samples.csproj
+++ b/samples/MerQure.Samples/MerQure.Samples.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0-pre3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/MerQure.Samples/merqure.rbmq.json
+++ b/samples/MerQure.Samples/merqure.rbmq.json
@@ -5,6 +5,7 @@
     "publisherAcknowledgementsTimeoutInMilliseconds": 10000,
     "connection": {
         "connectionString": "amqp://guest:guest@localhost:5672/",
+        "friendlyName": "merqure-sample",
         "automaticRecoveryEnabled": false,
         "topologyRecoveryEnabled": false
     }

--- a/src/MerQure.RbMQ/Config/MerQureConnection.cs
+++ b/src/MerQure.RbMQ/Config/MerQureConnection.cs
@@ -7,13 +7,19 @@ namespace MerQure.RbMQ.Config
         public const string DefaultConnectionString = "amqp://guest:guest@localhost:5672/";
         private const string AutomaticRecoveryEnabledPropertyName = "automaticRecoveryEnabled";
         private const string TopologyRecoveryEnabledPropertyName = "topologyRecoveryEnabled";
+        private const ushort DefaultRequestedChannelMax = 0;
 
         /// <summary>
         /// ConnectionString Uri to rabbitMQ server
         /// </summary>
         public String ConnectionString { get; set; } = DefaultConnectionString;
 
+        public String FriendlyName { get; set; }
+
         public bool AutomaticRecoveryEnabled { get; set; } = true;
+
         public bool TopologyRecoveryEnabled { get; set; } = true;
+
+        public ushort RequestedChannelMax { get; set; } = DefaultRequestedChannelMax;
     }
 }

--- a/src/MerQure.RbMQ/MerQure.RbMQ.csproj
+++ b/src/MerQure.RbMQ/MerQure.RbMQ.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0-pre3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MerQure.RbMQ/SharedConnection.cs
+++ b/src/MerQure.RbMQ/SharedConnection.cs
@@ -27,7 +27,9 @@ namespace MerQure.RbMQ
             {
                 Uri = new Uri(rabbitMqConnection.ConnectionString),
                 AutomaticRecoveryEnabled = rabbitMqConnection.AutomaticRecoveryEnabled,
-                TopologyRecoveryEnabled = rabbitMqConnection.TopologyRecoveryEnabled
+                TopologyRecoveryEnabled = rabbitMqConnection.TopologyRecoveryEnabled,
+                ClientProvidedName = rabbitMqConnection.FriendlyName,
+                RequestedChannelMax = rabbitMqConnection.RequestedChannelMax
             };
             return connectionFactory.CreateConnection();
         }

--- a/src/MerQure.RbMQ/rabbitMQ.config.model
+++ b/src/MerQure.RbMQ/rabbitMQ.config.model
@@ -6,6 +6,8 @@
   
   <connection
     connectionString="amqp://guest:guest@localhost:5672/"
+    friendlyName="myAppName"
+    requestedChannelMax="0"
     automaticRecoveryEnabled="true"
     topologyRecoveryEnabled="true" />
 

--- a/tests/MerQure.RbMQ.Tests/MerQure.RbMQ.Tests.csproj
+++ b/tests/MerQure.RbMQ.Tests/MerQure.RbMQ.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0-pre3" />
 	<PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
RbMq client upgraded to set a friendly name on connections.
ps. issue ```connection.clientProperties["connection_name"]``` not fixed in previous version.