### PR TITLE
[FIX] An empty routing key should not throw ArgumentNullException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.3 - 2018-12-06
+### Fixed
+- RabbitMQ : An empty routing key was throwing an ArgumentNullException on DeclareBinding.
+
 ## 0.5.2 - 2018-11-21
 ### Added
 - 2 new parameters on rabbitMq connection: friendlyName & requestedChannelMax

--- a/src/MerQure.RbMQ/MessagingService.cs
+++ b/src/MerQure.RbMQ/MessagingService.cs
@@ -98,7 +98,7 @@ namespace MerQure.RbMQ
         {
             if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
             if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
-            if (string.IsNullOrWhiteSpace(routingKey)) throw new ArgumentNullException(nameof(routingKey));
+            if (routingKey == null) throw new ArgumentNullException(nameof(routingKey));
 
             using (var channel = CurrentConnection.CreateModel())
             {
@@ -110,7 +110,7 @@ namespace MerQure.RbMQ
         {
             if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
             if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
-            if (string.IsNullOrWhiteSpace(routingKey)) throw new ArgumentNullException(nameof(routingKey));
+            if (routingKey == null) throw new ArgumentNullException(nameof(routingKey));
 
             using (var channel = CurrentConnection.CreateModel())
             {

--- a/tests/MerQure.RbMQ.Tests/MessagingServiceTests.cs
+++ b/tests/MerQure.RbMQ.Tests/MessagingServiceTests.cs
@@ -31,6 +31,8 @@ namespace MerQure.RbMQ.Tests
 
             Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding(null, "queue", "routing"));
             Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("exhange", null, "routing"));
+            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("", "queue", "routing"));
+            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("exhange", "", "routing"));
             Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("exhange", "queue", null));
         }
 


### PR DESCRIPTION
Since not all exchanges use routing key (fanout or header exchanges do not), empty routing key should be allowed.