### PR TITLE
RabbitMqClient v6 => v7

### DIFF
--- a/samples/MerQure.Samples/DeadLetterExample.cs
+++ b/samples/MerQure.Samples/DeadLetterExample.cs
@@ -1,62 +1,62 @@
 ﻿using MerQure.RbMQ.Content;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace MerQure.Samples
+namespace MerQure.Samples;
+
+public class DeadLetterExample
 {
-    public class DeadLetterExample
+    private readonly IMessagingService _messagingService;
+
+    public DeadLetterExample(IMessagingService messagingService)
     {
-        private readonly IMessagingService _messagingService;
+        _messagingService = messagingService;
+    }
 
-        public DeadLetterExample(IMessagingService messagingService)
+    public async Task RunAsync()
+    {
+        // RabbitMQ init
+        await _messagingService.DeclareExchangeAsync("deadletter.exchange", Constants.ExchangeTypeFanout);
+        await _messagingService.DeclareQueueAsync("deadletter.queue", isQuorum: true);
+        await _messagingService.DeclareBindingAsync("deadletter.exchange", "deadletter.queue", "#");
+
+        await _messagingService.DeclareExchangeAsync("delay.exchange", Constants.ExchangeTypeHeaders);
+        await _messagingService.DeclareQueueWithDeadLetterPolicyAsync("deadletter.queue.5", "deadletter.exchange", 5000, null, isQuorum: true);
+        await _messagingService.DeclareQueueWithDeadLetterPolicyAsync("deadletter.queue.30", "deadletter.exchange", 30000, null, isQuorum: true);
+
+        await _messagingService.DeclareBindingAsync("delay.exchange", "deadletter.queue.5", "#", new Dictionary<string, object> { { "delay", 5 } });
+        await _messagingService.DeclareBindingAsync("delay.exchange", "deadletter.queue.30", "#", new Dictionary<string, object> { { "delay", 30 } });
+
+        var dateStart = DateTime.Now;
+
+        // Get the publisher and publish messages
+        await using (var publisher = await _messagingService.GetPublisherAsync("delay.exchange"))
         {
-            _messagingService = messagingService;
-        }
-
-        public void Run()
-        {
-            // RabbitMQ init
-            _messagingService.DeclareExchange("deadletter.exchange", Constants.ExchangeTypeFanout);
-            _messagingService.DeclareQueue("deadletter.queue", isQuorum: true);
-            _messagingService.DeclareBinding("deadletter.exchange", "deadletter.queue", "#");
-
-            _messagingService.DeclareExchange("delay.exchange", Constants.ExchangeTypeHeaders);
-            _messagingService.DeclareQueueWithDeadLetterPolicy("deadletter.queue.5", "deadletter.exchange", 5000, null, isQuorum: true);
-            _messagingService.DeclareQueueWithDeadLetterPolicy("deadletter.queue.30", "deadletter.exchange", 30000, null, isQuorum: true);
-
-            _messagingService.DeclareBinding("delay.exchange", "deadletter.queue.5", "#", new Dictionary<string, object> { { "delay", 5 } });
-            _messagingService.DeclareBinding("delay.exchange", "deadletter.queue.30", "#", new Dictionary<string, object> { { "delay", 30 } });
-
-            var dateStart = DateTime.Now;
-
-            // Get the publisher and publish messages
-            using (var publisher = _messagingService.GetPublisher("delay.exchange"))
+            // publish messages waiting 5s
+            for (int i = 0; i <= 10; i++)
             {
-                // publish messages waiting 5s
-                for (int i = 0; i <= 10; i++)
-                {
-                    var message = new Message($"delay.5.message.{i}", $"Waited 5s: {i} !");
-                    message.Header.GetProperties().Add("delay", 5);
-                    publisher.Publish(message);
-                }
-                // publish messages waiting 30s
-                for (int i = 0; i <= 10; i++)
-                {
-                    var message = new Message($"delay.30.message.{i}", $"Waited 30s: {i} !");
-                    message.Header.GetProperties().Add("delay", 30);
-                    publisher.Publish(message);
-                }
+                var message = new Message($"delay.5.message.{i}", $"Waited 5s: {i} !");
+                message.Header.GetProperties().Add("delay", 5);
+                await publisher.PublishAsync(message);
             }
-
-            // Get the consumer on the existing queue and consume its messages
-            var consumer = _messagingService.GetConsumer("deadletter.queue");
-            consumer.Consume((object sender, IMessagingEvent args) =>
+            // publish messages waiting 30s
+            for (int i = 0; i <= 10; i++)
             {
-                var realDelay = DateTime.Now.Subtract(dateStart).TotalSeconds;
-                Console.WriteLine(string.Format("{0} received after {1:#.##}s.", args.Message.GetRoutingKey(), realDelay));
-                // send ACK: acknowlegdment to the queue 
-                consumer.AcknowlegdeDeliveredMessage(args);
-            });
+                var message = new Message($"delay.30.message.{i}", $"Waited 30s: {i} !");
+                message.Header.GetProperties().Add("delay", 30);
+                await publisher.PublishAsync(message);
+            }
         }
+
+        // Get the consumer on the existing queue and consume its messages
+        var consumer = await _messagingService.GetConsumerAsync("deadletter.queue");
+        await consumer.ConsumeAsync((object sender, IMessagingEvent args) =>
+        {
+            var realDelay = DateTime.Now.Subtract(dateStart).TotalSeconds;
+            Console.WriteLine(string.Format("{0} received after {1:#.##}s.", args.Message.GetRoutingKey(), realDelay));
+            // send ACK: acknowlegdment to the queue
+            consumer.AcknowlegdeDeliveredMessageAsync(args);
+        });
     }
 }

--- a/samples/MerQure.Samples/MerQure.Samples.csproj
+++ b/samples/MerQure.Samples/MerQure.Samples.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/MerQure.Samples/Program.cs
+++ b/samples/MerQure.Samples/Program.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace MerQure.Samples
 {
     static class Program
     {
-        static void Main()
+        static async Task Main()
         {
             IServiceCollection services = new ServiceCollection();
 
@@ -16,17 +18,17 @@ namespace MerQure.Samples
 
             Console.WriteLine("Running sample 1: simple");
             var simpleExample = serviceProvider.GetService<SimpleExample>();
-            simpleExample.Run();
+            await simpleExample.RunAsync();
 
-            System.Threading.Thread.Sleep(500);
+            Thread.Sleep(500);
             Console.WriteLine("Running sample 2: stop");
             var stopExample = serviceProvider.GetService<StopExample>();
-            stopExample.Run();
+            await stopExample.RunAsync();
 
-            System.Threading.Thread.Sleep(500);
+            Thread.Sleep(500);
             Console.WriteLine("Running sample 3: deadletter");
             var deadLetterExample = serviceProvider.GetService<DeadLetterExample>();
-            deadLetterExample.Run();
+            await deadLetterExample.RunAsync();
         }
     }
 }

--- a/samples/MerQure.Samples/SimpleExample.cs
+++ b/samples/MerQure.Samples/SimpleExample.cs
@@ -1,54 +1,52 @@
 ﻿using MerQure.RbMQ.Content;
 using System;
+using System.Threading.Tasks;
 
-namespace MerQure.Samples
+namespace MerQure.Samples;
+
+public class SimpleExample
 {
-    public class SimpleExample
+    private readonly IMessagingService _messagingService;
+
+    public SimpleExample(IMessagingService messagingService)
     {
-        private readonly IMessagingService _messagingService;
+        _messagingService = messagingService;
+    }
 
-        public SimpleExample(IMessagingService messagingService)
+    public async Task RunAsync()
+    {
+        // RabbitMQ init
+        await _messagingService.DeclareExchangeAsync("simple.exchange");
+        await _messagingService.DeclareQueueAsync("simple.queue", isQuorum: true);
+        await _messagingService.DeclareBindingAsync("simple.exchange", "simple.queue", "simple.message.*");
+
+        // Get the publisher and declare Exhange where publish messages
+        await using var publisher = await _messagingService.GetPublisherAsync("simple.exchange");
+        // publish messages
+        for (int i = 0; i <= 10; i++)
         {
-            _messagingService = messagingService;
+            await publisher.PublishAsync(new Message($"simple.message.test{i}", $"Hello world {i} !"));
         }
 
-        public void Run()
-        {
-            // RabbitMQ init
-            _messagingService.DeclareExchange("simple.exchange");
-            _messagingService.DeclareQueue("simple.queue", isQuorum: true);
-            _messagingService.DeclareBinding("simple.exchange", "simple.queue", "simple.message.*");
 
-            // Get the publisher and declare Exhange where publish messages
-            using (var publisher = _messagingService.GetPublisher("simple.exchange"))
+        // Get the consumer on the existing queue and consume its messages
+        var consumer = await _messagingService.GetConsumerAsync("simple.queue");
+        var random = new Random();
+        await consumer.ConsumeAsync((object sender, IMessagingEvent args) =>
+        {
+            // we simulate the delivery success
+            if (random.Next() % 2 == 0)
             {
-                // publish messages
-                for (int i = 0; i <= 10; i++)
-                {
-                    publisher.Publish(new Message($"simple.message.test{i}", $"Hello world {i} !"));
-                }
+                Console.WriteLine("Retry " + args.Message.GetRoutingKey());
+                // send NACK: negative acknowlegdment to the queue
+                consumer.RejectDeliveredMessageAsync(args);
             }
-
-
-            // Get the consumer on the existing queue and consume its messages
-            var consumer = _messagingService.GetConsumer("simple.queue");
-            var random = new Random();
-            consumer.Consume((object sender, IMessagingEvent args) =>
+            else
             {
-                // we simulate the delivery success
-                if (random.Next() % 2 == 0)
-                {
-                    Console.WriteLine("Retry " + args.Message.GetRoutingKey());
-                    // send NACK: negative acknowlegdment to the queue
-                    consumer.RejectDeliveredMessage(args);
-                }
-                else
-                {
-                    Console.WriteLine(args.Message.GetBody());
-                    // send ACK: acknowlegdment to the queue 
-                    consumer.AcknowlegdeDeliveredMessage(args);
-                }
-            });
-        }
+                Console.WriteLine(args.Message.GetBody());
+                // send ACK: acknowlegdment to the queue
+                consumer.AcknowlegdeDeliveredMessageAsync(args);
+            }
+        });
     }
 }

--- a/samples/MerQure.Tools.Samples/Program.cs
+++ b/samples/MerQure.Tools.Samples/Program.cs
@@ -1,29 +1,29 @@
 ﻿using MerQure.Tools.Samples.RetryBusExample.Domain;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading.Tasks;
 
-namespace MerQure.Tools.Samples
+namespace MerQure.Tools.Samples;
+
+public static class Program
 {
-	public static class Program
+	static async Task Main(string[] args)
 	{
-		static void Main(string[] args)
+		IServiceCollection services = new ServiceCollection();
+
+		var startup = new Startup();
+		startup.ConfigureServices(services);
+
+		var serviceProvider = services.BuildServiceProvider();
+
+		var actionService = serviceProvider.GetService<ActionService>();
+		await actionService.ConsumeAsync();
+
+		for (int i = 0; i < 50; i++)
 		{
-			IServiceCollection services = new ServiceCollection();
-
-			var startup = new Startup();
-			startup.ConfigureServices(services);
-
-			var serviceProvider = services.BuildServiceProvider();
-
-			var actionService = serviceProvider.GetService<ActionService>();
-			actionService.Consume();
-
-			for (int i = 0; i < 50; i++)
-			{
-				actionService.SendNewSample();
-			}
-
-			Console.ReadLine();
+			await actionService.SendNewSampleAsync();
 		}
+
+		Console.ReadLine();
 	}
 }

--- a/samples/MerQure.Tools.Samples/RetryBusExample/Domain/ActionService.cs
+++ b/samples/MerQure.Tools.Samples/RetryBusExample/Domain/ActionService.cs
@@ -1,68 +1,67 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace MerQure.Tools.Samples.RetryBusExample.Domain
+namespace MerQure.Tools.Samples.RetryBusExample.Domain;
+
+public class ActionService
 {
-	public class ActionService
+    private int _fakeError;
+
+    private readonly ISampleService _sampleService;
+
+    public ActionService(ISampleService sampleService)
     {
-        private int _fakeError;
+        _sampleService = sampleService;
+    }
 
-        private readonly ISampleService _sampleService;
-
-        public ActionService(ISampleService sampleService)
+    public Task SendNewSampleAsync()
+    {
+        return _sampleService.SendAsync(new Sample()
         {
-            _sampleService = sampleService;
+            Name = "MerQure Tools"
+        });
+    }
+
+    public async Task ConsumeAsync()
+    {
+        await _sampleService.ConsumeAsync(async (object sender, Sample sample) => await OnSampleReceivedAsync(sender, sample));
+    }
+
+    public async Task OnSampleReceivedAsync(object sender, Sample sample)
+    {
+        try
+        {
+            await ManageNewSampleAsync(sample);
         }
-
-        public void SendNewSample()
+        catch (SampleException)
         {
-            _sampleService.Send(new Sample()
-            {
-                Name = "MerQure Tools"
-            });
+            await _sampleService.RetryLaterAsync(sample);
         }
-
-        public void Consume()
+        catch (Exception)
         {
-            _sampleService.Consume(async (object sender, Sample sample) => await OnSampleReceived(sender, sample));
+            await _sampleService.SendOnErrorAsync(sample);
+            //...
         }
+    }
 
-        public async Task OnSampleReceived(object sender, Sample sample)
+    private async Task ManageNewSampleAsync(Sample sample)
+    {
+        _fakeError++;
+
+        int value = new Random().Next(1000, 3000);
+        await Task.Delay(value);
+        if (_fakeError % 15 == 0)
         {
-            try
-            {
-                await ManageNewSample(sample);
-            }
-            catch (SampleException)
-            {
-                _sampleService.RetryLater(sample);
-            }
-            catch (Exception)
-            {
-                _sampleService.SendOnError(sample);
-                //...
-            }
+            throw new SampleException("This is an unmanageable exception, like NPE");
         }
-
-        private async Task ManageNewSample(Sample sample)
+        else if (_fakeError % 5 == 0)
         {
-            _fakeError++;
-
-            int value = new Random().Next(1000, 3000);
-            await Task.Delay(value);
-            if (_fakeError % 15 == 0)
-            {
-                throw new SampleException("This is an unmanageable exception, like NPE");
-            }
-            else if (_fakeError % 5 == 0)
-            {
-                throw new SampleException("This is an \"retry later\" exception");
-            }
-            else
-            {
-                //everything ok
-                _sampleService.Acknowlegde(sample);
-            }
+            throw new SampleException("This is an \"retry later\" exception");
+        }
+        else
+        {
+            //everything ok
+            await _sampleService.AcknowlegdeAsync(sample);
         }
     }
 }

--- a/samples/MerQure.Tools.Samples/RetryBusExample/Domain/ISampleService.cs
+++ b/samples/MerQure.Tools.Samples/RetryBusExample/Domain/ISampleService.cs
@@ -1,14 +1,14 @@
 ﻿
 using System;
+using System.Threading.Tasks;
 
-namespace MerQure.Tools.Samples.RetryBusExample.Domain
+namespace MerQure.Tools.Samples.RetryBusExample.Domain;
+
+public interface ISampleService
 {
-	public interface ISampleService
-    {
-        void Send(Sample sample);
-        void Consume(EventHandler<Sample> onSampleReceived);
-        void Acknowlegde(Sample sample);
-        void RetryLater(Sample sample);
-        void SendOnError(Sample sample); 
-    }
+    Task SendAsync(Sample sample);
+    Task ConsumeAsync(EventHandler<Sample> onSampleReceived);
+    Task AcknowlegdeAsync(Sample sample);
+    Task RetryLaterAsync(Sample sample);
+    Task SendOnErrorAsync(Sample sample);
 }

--- a/samples/MerQure.Tools.Samples/Startup.cs
+++ b/samples/MerQure.Tools.Samples/Startup.cs
@@ -1,7 +1,7 @@
 ﻿using MerQure.RbMQ;
 using MerQure.RbMQ.Config;
 using MerQure.Tools.Samples.RetryBusExample.Domain;
-using MerQure.Tools.Samples.RetryBusExample.RetryExchangeExample.Infra;
+using MerQure.Tools.Samples.RetryBusExample.Infra;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.IO;

--- a/src/MerQure.RbMQ/Clients/Consumer.cs
+++ b/src/MerQure.RbMQ/Clients/Consumer.cs
@@ -85,7 +85,6 @@ class Consumer : RabbitMqClient, IConsumer
         return _consumer != null && _consumer.IsRunning;
     }
 
-    // TODO : async
     public async Task StopConsuming(AsyncEventHandler<ConsumerEventArgs> onConsumerStopped)
     {
         if (IsConsuming())

--- a/src/MerQure.RbMQ/Clients/Consumer.cs
+++ b/src/MerQure.RbMQ/Clients/Consumer.cs
@@ -7,114 +7,117 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
-namespace MerQure.RbMQ.Clients
+namespace MerQure.RbMQ.Clients;
+
+class Consumer : RabbitMqClient, IConsumer
 {
-    class Consumer : RabbitMqClient, IConsumer
+    public string QueueName { get; }
+
+    private AsyncEventingBasicConsumer _consumer;
+    private readonly ushort _prefetchCount;
+    private readonly object _consumingLock;
+
+    public Consumer(IChannel channel, string queueName, ushort prefetchCount)
+        : base(channel)
     {
-        public string QueueName { get; }
-        
-        private EventingBasicConsumer _consumer;
-        private readonly ushort _prefetchCount;
-        private readonly object _consumingLock;
+        QueueName = queueName.ToLowerInvariant();
+        _prefetchCount = prefetchCount;
+        _consumingLock = new object();
+    }
 
-        public Consumer(IModel channel, string queueName, ushort prefetchCount)
-            : base(channel)
+    public async Task ConsumeAsync(EventHandler<IMessagingEvent> onMessageReceived)
+    {
+        await Channel.BasicQosAsync(0, _prefetchCount, false);
+
+        _consumer = new AsyncEventingBasicConsumer(Channel);
+        _consumer.ReceivedAsync += (sender, args) =>
         {
-            this.QueueName = queueName.ToLowerInvariant();
-            _prefetchCount = prefetchCount;
-            _consumingLock = new object();
-        }
-
-        public void Consume(EventHandler<IMessagingEvent> onMessageReceived)
-        {
-            this.Channel.BasicQos(0, _prefetchCount, false);
-
-            _consumer = new EventingBasicConsumer(Channel);
-            _consumer.Received += ((object sender, BasicDeliverEventArgs args) =>
-            {
-                if (onMessageReceived != null)
-                {
-                    lock (_consumingLock)
-                    {
-                        var message = ParseDeliveredMessage(args);
-                        var messageEventArgs = new MessagingEvent(message, args.DeliveryTag.ToString());
-                        onMessageReceived(sender, messageEventArgs);
-                    }
-                }
-            });
-
-            Channel.BasicConsume(this.QueueName, false, _consumer);
-        }
-
-        private IMessage ParseDeliveredMessage(BasicDeliverEventArgs args)
-        {
-            return new Message(
-                args.RoutingKey,
-                ParseHeader(args),
-                Encoding.UTF8.GetString(args.Body.ToArray())
-            );
-        }
-
-        private Header ParseHeader(BasicDeliverEventArgs args)
-        {
-            return new Header(
-                args.BasicProperties.Headers?
-                    .ToDictionary(kvp => kvp.Key, kvp => ParseHeaderProperty(kvp.Value)) 
-                ?? new Dictionary<string, object>());
-        }
-        /// <summary>
-        /// Parse header properties, ignoring complex type as "Nested Table"
-        /// </summary>
-        /// <param name="propertyValue"></param>
-        /// <returns></returns>
-        /// <see cref="https://www.rabbitmq.com/amqp-0-9-1-errata.html"/>
-        private object ParseHeaderProperty(object propertyValue)
-        {
-            if (propertyValue is byte[])
-            {
-                return Encoding.UTF8.GetString((byte[])propertyValue);
-            }
-            return propertyValue;
-        }
-
-        public bool IsConsuming()
-        {
-            return _consumer != null && _consumer.IsRunning;
-        }
-
-        public void StopConsuming(EventHandler onConsumerStopped)
-        {
-            if (IsConsuming())
+            if (onMessageReceived != null)
             {
                 lock (_consumingLock)
                 {
-                    if (onConsumerStopped != null)
-                    {
-                        _consumer.ConsumerCancelled += ((object sender, ConsumerEventArgs e) => 
-                        {
-                            onConsumerStopped(sender, e);
-                        });
-                    }
-
-                    foreach (var tag in _consumer.ConsumerTags)
-                    {
-                        Channel.BasicCancel(tag);
-                    }
+                    var message = ParseDeliveredMessage(args);
+                    var messageEventArgs = new MessagingEvent(message, args.DeliveryTag.ToString());
+                    onMessageReceived(sender, messageEventArgs);
                 }
             }
-        }
+            return Task.CompletedTask;
+        };
 
-        public void AcknowlegdeDeliveredMessage(IDelivered deliveredMessage)
+        await Channel.BasicConsumeAsync(QueueName, false, _consumer);
+    }
+
+    private IMessage ParseDeliveredMessage(BasicDeliverEventArgs args)
+    {
+        return new Message(
+            args.RoutingKey,
+            ParseHeader(args),
+            Encoding.UTF8.GetString(args.Body.ToArray())
+        );
+    }
+
+    private Header ParseHeader(BasicDeliverEventArgs args)
+    {
+        return new Header(
+            args.BasicProperties.Headers?
+                .ToDictionary(kvp => kvp.Key, kvp => ParseHeaderProperty(kvp.Value))
+            ?? new Dictionary<string, object>());
+    }
+    /// <summary>
+    /// Parse header properties, ignoring complex type as "Nested Table"
+    /// </summary>
+    /// <param name="propertyValue"></param>
+    /// <returns></returns>
+    /// <see cref="https://www.rabbitmq.com/amqp-0-9-1-errata.html"/>
+    private object ParseHeaderProperty(object propertyValue)
+    {
+        if (propertyValue is byte[])
         {
-            this.Channel.BasicAck(ulong.Parse(deliveredMessage.DeliveryTag), false);
+            return Encoding.UTF8.GetString((byte[])propertyValue);
         }
-        
+        return propertyValue;
+    }
 
-        public void RejectDeliveredMessage(IDelivered deliveredMessage)
+    public bool IsConsuming()
+    {
+        return _consumer != null && _consumer.IsRunning;
+    }
+
+    // TODO : async
+    public async Task StopConsuming(AsyncEventHandler<ConsumerEventArgs> onConsumerStopped)
+    {
+        if (IsConsuming())
         {
-            this.Channel.BasicNack(ulong.Parse(deliveredMessage.DeliveryTag), false, true);
-        }
+            lock (_consumingLock)
+            {
+                if (onConsumerStopped != null)
+                {
+                    _consumer.UnregisteredAsync  += (sender, e) =>
+                    {
+                        onConsumerStopped(sender, e);
+                        return Task.CompletedTask;
+                    };
+                }
+            }
 
+            // Must be outside the lock to avoid deadlock
+            foreach (var tag in _consumer.ConsumerTags)
+            {
+                await Channel.BasicCancelAsync(tag);
+            }
+        }
+    }
+
+    public ValueTask AcknowlegdeDeliveredMessageAsync(IDelivered deliveredMessage)
+    {
+        return Channel.BasicAckAsync(ulong.Parse(deliveredMessage.DeliveryTag), false);
+    }
+
+
+    public ValueTask RejectDeliveredMessageAsync(IDelivered deliveredMessage)
+    {
+        return Channel.BasicNackAsync(ulong.Parse(deliveredMessage.DeliveryTag), false, true);
     }
 }

--- a/src/MerQure.RbMQ/Clients/RabbitMQClient.cs
+++ b/src/MerQure.RbMQ/Clients/RabbitMQClient.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using RabbitMQ.Client;
+using System.Threading.Tasks;
 
-namespace MerQure.RbMQ.Clients
+namespace MerQure.RbMQ.Clients;
+
+internal abstract class RabbitMqClient : IAsyncDisposable
 {
-    internal abstract class RabbitMqClient : IDisposable
+    /// <summary>
+    /// rabbitmq-dotnet-client key objet
+    /// </summary>
+    public IChannel Channel { get; set; }
+
+    protected RabbitMqClient(IChannel channel)
     {
-        /// <summary>
-        /// rabbitmq-dotnet-client key objet
-        /// </summary>
-        public IModel Channel { get; set; }
+        Channel = channel;
+    }
 
-        protected RabbitMqClient(IModel channel)
-        {
-            Channel = channel;
-        }
-
-        public void Dispose()
-        {
-            Channel?.Close();
-        }
+    public ValueTask DisposeAsync()
+    {
+        return new ValueTask(Channel?.CloseAsync());
     }
 }

--- a/src/MerQure.RbMQ/MerQure.RbMQ.csproj
+++ b/src/MerQure.RbMQ/MerQure.RbMQ.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MerQure.RbMQ/MessagingService.cs
+++ b/src/MerQure.RbMQ/MessagingService.cs
@@ -4,170 +4,165 @@ using Microsoft.Extensions.Options;
 using RabbitMQ.Client;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace MerQure.RbMQ
+namespace MerQure.RbMQ;
+
+public class MessagingService : IMessagingService
 {
-    public class MessagingService : IMessagingService
+    public string ExchangeType { get; set; } = RabbitMQ.Client.ExchangeType.Topic;
+    public bool Durable { get; set; }
+    public bool AutoDeleteQueue { get; set; }
+    public ushort DefaultPrefetchCount { get; set; }
+    public long PublisherAcknowledgementsTimeoutInMilliseconds { get; set; }
+
+    protected Task<IConnection> CurrentConnection => _sharedConnection.CurrentConnection;
+
+    private readonly SharedConnection _sharedConnection;
+
+    public MessagingService(IOptions<MerQureConfiguration> merQureConfiguration, SharedConnection sharedConnection)
     {
-        public string ExchangeType { get; set; } = RabbitMQ.Client.ExchangeType.Topic;
-        public bool Durable { get; set; }
-        public bool AutoDeleteQueue { get; set; }
-        public ushort DefaultPrefetchCount { get; set; }
-        public long PublisherAcknowledgementsTimeoutInMilliseconds { get; set; }
+        _sharedConnection = sharedConnection;
 
-        protected IConnection CurrentConnection => _sharedConnection.CurrentConnection;
-
-        private readonly SharedConnection _sharedConnection;
-
-        public MessagingService(IOptions<MerQureConfiguration> merQureConfiguration, SharedConnection sharedConnection)
+        if (merQureConfiguration == null)
         {
-            _sharedConnection = sharedConnection;
+            return;
+        }
+        Durable = merQureConfiguration.Value.Durable;
+        AutoDeleteQueue = merQureConfiguration.Value.AutoDeleteQueue;
+        DefaultPrefetchCount = merQureConfiguration.Value.DefaultPrefetchCount;
+        PublisherAcknowledgementsTimeoutInMilliseconds = merQureConfiguration.Value.PublisherAcknowledgementsTimeoutInMilliseconds;
+    }
 
-            if (merQureConfiguration == null)
+    public Task DeclareExchangeAsync(string exchangeName)
+    {
+        return DeclareExchangeAsync(exchangeName, ExchangeType);
+    }
+
+    public async Task DeclareExchangeAsync(string exchangeName, string exchangeType)
+    {
+        if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
+
+        var connection = await CurrentConnection;
+        await using var channel = await connection.CreateChannelAsync();
+        await channel.ExchangeDeclareAsync(exchangeName.ToLowerInvariant(), exchangeType, this.Durable);
+    }
+
+    public Task<string> DeclareQueueAsync(string queueName, byte maxPriority, bool isQuorum)
+    {
+        var queueArgs = new Dictionary<string, object> {
+            { Constants.QueueMaxPriority, maxPriority }
+        };
+        return DeclareQueueAsync(queueName, queueArgs, isQuorum);
+    }
+
+    public Task<string> DeclareQueueAsync(string queueName, bool isQuorum)
+    {
+        return DeclareQueueAsync(queueName, new Dictionary<string, object>(), isQuorum);
+    }
+
+    public Task<string> DeclareQueueWithDeadLetterPolicyAsync(string queueName, string deadLetterExchange, int messageTimeToLive, string deadLetterRoutingKey, bool isQuorum)
+    {
+        if (string.IsNullOrWhiteSpace(deadLetterExchange)) throw new ArgumentNullException(nameof(deadLetterExchange));
+        if (messageTimeToLive <= 0) throw new ArgumentOutOfRangeException(nameof(messageTimeToLive));
+
+        var queueArgs = new Dictionary<string, object> {
+            { Constants.QueueDeadLetterExchange, deadLetterExchange },
+            { Constants.QueueMessageTTL, messageTimeToLive }
+        };
+        if (!string.IsNullOrEmpty(deadLetterRoutingKey))
+        {
+            queueArgs.Add(Constants.QueueDeadLetterRoutingKey, deadLetterRoutingKey);
+        }
+        return DeclareQueueAsync(queueName, queueArgs, isQuorum);
+    }
+    private const string QuorumQueueNameSuffix ="-q";
+
+    public async Task<string> DeclareQueueAsync(string queueName, Dictionary<string, object> queueArgs, bool isQuorum)
+    {
+        if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
+        if (queueArgs == null) throw new ArgumentNullException(nameof(queueArgs));
+
+        Dictionary<string, object> effectiveQueueArgs;
+        string effectiveQueueName;
+        if(isQuorum)
+        {
+            if(!Durable || AutoDeleteQueue)
             {
-                return;
+                throw new ArgumentException("Quorum queues must be durable and non-auto-delete");
             }
-            Durable = merQureConfiguration.Value.Durable;
-            AutoDeleteQueue = merQureConfiguration.Value.AutoDeleteQueue;
-            DefaultPrefetchCount = merQureConfiguration.Value.DefaultPrefetchCount;
-            PublisherAcknowledgementsTimeoutInMilliseconds = merQureConfiguration.Value.PublisherAcknowledgementsTimeoutInMilliseconds;
-        }
-
-        public void DeclareExchange(string exchangeName)
-        {
-            DeclareExchange(exchangeName, this.ExchangeType);
-        }
-
-        public void DeclareExchange(string exchangeName, string exchangeType)
-        {
-            if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
-
-            using (var channel = CurrentConnection.CreateModel())
+            effectiveQueueArgs = new Dictionary<string, object>(queueArgs)
             {
-                channel.ExchangeDeclare(exchangeName.ToLowerInvariant(), exchangeType, this.Durable);
-            }
-        }
-
-        public string DeclareQueue(string queueName, byte maxPriority, bool isQuorum)
-        {
-            var queueArgs = new Dictionary<string, object> {
-                { Constants.QueueMaxPriority, maxPriority }
+                { Constants.HeaderQueueType, Constants.HeaderQueueTypeQuorumValue }
             };
-            return DeclareQueue(queueName, queueArgs, isQuorum);
+            effectiveQueueName = $"{queueName}{QuorumQueueNameSuffix}";
         }
-
-        public string DeclareQueue(string queueName, bool isQuorum)
+        else
         {
-            return DeclareQueue(queueName, new Dictionary<string, object>(), isQuorum);
+            effectiveQueueArgs = queueArgs;
+            effectiveQueueName = queueName;
         }
 
-        public string DeclareQueueWithDeadLetterPolicy(string queueName, string deadLetterExchange, int messageTimeToLive, string deadLetterRoutingKey, bool isQuorum)
-        {
-            if (string.IsNullOrWhiteSpace(deadLetterExchange)) throw new ArgumentNullException(nameof(deadLetterExchange));
-            if (messageTimeToLive <= 0) throw new ArgumentOutOfRangeException(nameof(messageTimeToLive));
+        var connection = await CurrentConnection;
+        await using var channel = await connection.CreateChannelAsync();
+        await channel.QueueDeclareAsync(effectiveQueueName.ToLowerInvariant(), this.Durable, false, this.AutoDeleteQueue, effectiveQueueArgs);
 
-            var queueArgs = new Dictionary<string, object> {
-                { Constants.QueueDeadLetterExchange, deadLetterExchange },
-                { Constants.QueueMessageTTL, messageTimeToLive }
-            };
-            if (!string.IsNullOrEmpty(deadLetterRoutingKey))
-            {
-                queueArgs.Add(Constants.QueueDeadLetterRoutingKey, deadLetterRoutingKey);
-            }
-            return DeclareQueue(queueName, queueArgs, isQuorum);
-        }
-        private const string QuorumQueueNameSuffix ="-q";
+        return effectiveQueueName;
+    }
 
-        public string DeclareQueue(string queueName, Dictionary<string, object> queueArgs, bool isQuorum)
-        {
-            if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
-            if (queueArgs == null) throw new ArgumentNullException(nameof(queueArgs));
+    public Task DeclareBindingAsync(string exchangeName, string queueName, string routingKey)
+    {
+        return DeclareBindingAsync(exchangeName, queueName, routingKey, null);
+    }
+    public async Task DeclareBindingAsync(string exchangeName, string queueName, string routingKey, Dictionary<string, object> headerBindings)
+    {
+        if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
+        if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
+        if (routingKey == null) throw new ArgumentNullException(nameof(routingKey));
 
-            Dictionary<string, object> effectiveQueueArgs;
-            string effectiveQueueName;
-            if(isQuorum)
-            {
-                if(!Durable || AutoDeleteQueue)
-                {
-                    throw new ArgumentException("Quorum queues must be durable and non-auto-delete");
-                }
-                effectiveQueueArgs = new Dictionary<string, object>(queueArgs)
-                {
-                    { Constants.HeaderQueueType, Constants.HeaderQueueTypeQuorumValue }
-                };
-                effectiveQueueName = $"{queueName}{QuorumQueueNameSuffix}";
-            }
-            else
-            {
-                effectiveQueueArgs = queueArgs;
-                effectiveQueueName = queueName;
-            }
+        var connection = await CurrentConnection;
+        await using var channel = await connection.CreateChannelAsync();
+        await channel.QueueBindAsync(queueName.ToLowerInvariant(), exchangeName.ToLowerInvariant(), routingKey.ToLowerInvariant(), headerBindings);
+    }
 
-            using (var channel = CurrentConnection.CreateModel())
-            {
-                channel.QueueDeclare(effectiveQueueName.ToLowerInvariant(), this.Durable, false, this.AutoDeleteQueue, effectiveQueueArgs);
-            }
+    public async Task CancelBindingAsync(string exchangeName, string queueName, string routingKey)
+    {
+        if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
+        if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
+        if (routingKey == null) throw new ArgumentNullException(nameof(routingKey));
 
-            return effectiveQueueName;
-        }
+        var connection = await CurrentConnection;
+        await using var channel = await connection.CreateChannelAsync();
+        await channel.QueueUnbindAsync(queueName.ToLowerInvariant(), exchangeName.ToLowerInvariant(), routingKey.ToLowerInvariant());
+    }
 
-        public void DeclareBinding(string exchangeName, string queueName, string routingKey)
-        {
-            DeclareBinding(exchangeName, queueName, routingKey, null);
-        }
-        public void DeclareBinding(string exchangeName, string queueName, string routingKey, Dictionary<string, object> headerBindings)
-        {
-            if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
-            if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
-            if (routingKey == null) throw new ArgumentNullException(nameof(routingKey));
+    public Task<IPublisher> GetPublisherAsync(string exchangeName)
+    {
+        return GetPublisherAsync(exchangeName, false);
+    }
 
-            using (var channel = CurrentConnection.CreateModel())
-            {
-                channel.QueueBind(queueName.ToLowerInvariant(), exchangeName.ToLowerInvariant(), routingKey.ToLowerInvariant(), headerBindings);
-            }
-        }
+    public async Task<IPublisher> GetPublisherAsync(string exchangeName, bool enablePublisherAcknowledgements)
+    {
+        if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
 
-        public void CancelBinding(string exchangeName, string queueName, string routingKey)
-        {
-            if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
-            if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
-            if (routingKey == null) throw new ArgumentNullException(nameof(routingKey));
+        var channelOptions = new CreateChannelOptions(enablePublisherAcknowledgements, enablePublisherAcknowledgements);
+        var connection = await CurrentConnection;
+        var channel = await connection.CreateChannelAsync(channelOptions);
 
-            using (var channel = CurrentConnection.CreateModel())
-            {
-                channel.QueueUnbind(queueName.ToLowerInvariant(), exchangeName.ToLowerInvariant(), routingKey.ToLowerInvariant());
-            }
-        }
+        return new Publisher(channel, exchangeName, PublisherAcknowledgementsTimeoutInMilliseconds);
+    }
 
-        public IPublisher GetPublisher(string exchangeName)
-        {
-            return GetPublisher(exchangeName, false);
-        }
+    public Task<IConsumer> GetConsumerAsync(string queueName)
+    {
+        return GetConsumerAsync(queueName, DefaultPrefetchCount);
+    }
 
-        public IPublisher GetPublisher(string exchangeName, bool enablePublisherAcknowledgements)
-        {
-            if (string.IsNullOrWhiteSpace(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
+    public async Task<IConsumer> GetConsumerAsync(string queueName, ushort prefetchCount)
+    {
+        if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
 
-            var channel = CurrentConnection.CreateModel();
-            if (enablePublisherAcknowledgements)
-            {
-                channel.ConfirmSelect();
-            }
-
-            return new Publisher(channel, exchangeName, PublisherAcknowledgementsTimeoutInMilliseconds);
-        }
-
-        public IConsumer GetConsumer(string queueName)
-        {
-            return GetConsumer(queueName, DefaultPrefetchCount);
-        }
-
-        public IConsumer GetConsumer(string queueName, ushort prefetchCount)
-        {
-            if (string.IsNullOrWhiteSpace(queueName)) throw new ArgumentNullException(nameof(queueName));
-
-            var channel = CurrentConnection.CreateModel();
-            return new Consumer(channel, queueName, prefetchCount);
-        }
+        var connection = await CurrentConnection;
+        var channel = await connection.CreateChannelAsync();
+        return new Consumer(channel, queueName, prefetchCount);
     }
 }

--- a/src/MerQure.Tools/Buses/Bus.cs
+++ b/src/MerQure.Tools/Buses/Bus.cs
@@ -2,58 +2,58 @@
 using MerQure.Tools.Configurations;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace MerQure.Tools.Buses
+namespace MerQure.Tools.Buses;
+
+internal class Bus<T> : IBus<T> where T : IDelivered
 {
-    internal class Bus<T> : IBus<T> where T : IDelivered
+    internal Publisher<T> Producer { get; set; }
+    internal RetryConsumer<T> Consumer { get; set; }
+
+    public Bus(Publisher<T> producer, RetryConsumer<T> consumer)
     {
-        internal Publisher<T> Producer { get; set; }
-        internal RetryConsumer<T> Consumer { get; set; }
+        Producer = producer;
+        Consumer = consumer;
+    }
 
-        public Bus(Publisher<T> producer, RetryConsumer<T> consumer)
-        {
-            Producer = producer;
-            Consumer = consumer;
-        }
+    public Task AcknowlegdeDeliveredMessageAsync(Channel channel, T deliveredMessage)
+    {
+        return Consumer.AcknowlegdeDeliveredMessageAsync(channel, deliveredMessage);
+    }
 
-        public void AcknowlegdeDeliveredMessage(Channel channel, T deliveredMessage)
-        {
-            Consumer.AcknowlegdeDeliveredMessage(channel, deliveredMessage);
-        }
+    public Task OnMessageReceivedAsync(Channel channel, EventHandler<T> callback)
+    {
+        return Consumer.ConsumeAsync(channel, callback);
+    }
 
-        public void OnMessageReceived(Channel channel, EventHandler<T> callback)
-        {
-            Consumer.Consume(channel, callback);
-        }
+    public Task PublishAsync(Channel channel, T message, bool applyDeliveryDeplay = false)
+    {
+        return Producer.PublishAsync(channel, message, applyDeliveryDeplay);
+    }
 
-        public void Publish(Channel channel, T message, bool applyDeliveryDeplay = false)
-        {
-            Producer.Publish(channel, message, applyDeliveryDeplay);
-        }
+    public Task PublishWithTransactionAsync (Channel channel, IEnumerable<T> messages, bool applyDeliveryDeplay = false)
+    {
+        return Producer.PublishWithTransactionAsync(channel, messages, applyDeliveryDeplay);
+    }
 
-        public void PublishWithTransaction(Channel channel, IEnumerable<T> messages, bool applyDeliveryDeplay = false)
-        {
-            Producer.PublishWithTransaction(channel, messages, applyDeliveryDeplay);
-        }
+    public Task RejectDeliveredMessageAsync(Channel channel, T deliveredMessage)
+    {
+        return Consumer.RejectDeliveredMessageAsync(channel, deliveredMessage);
+    }
 
-        public void RejectDeliveredMessage(Channel channel, T deliveredMessage)
-        {
-            Consumer.RejectDeliveredMessage(channel, deliveredMessage);
-        }
+    public Task<MessageInformations> ApplyRetryStrategyAsync(Channel channel, T deliveredMessage)
+    {
+        return Consumer.ApplyRetryStrategyAsync(channel, deliveredMessage);
+    }
 
-        public MessageInformations ApplyRetryStrategy(Channel channel, T deliveredMessage)
-        {
-            return Consumer.ApplyRetryStrategy(channel, deliveredMessage);
-        }
+    public Task SendDeliveredMessageToErrorBusAsync(Channel channel, T deliveredMessage)
+    {
+        return Consumer.SendToErrorExchangeAsync(channel, deliveredMessage);
+    }
 
-        public void SendDeliveredMessageToErrorBus(Channel channel, T deliveredMessage)
-        {
-            Consumer.SendToErrorExchange(channel, deliveredMessage);
-        }
-
-        public MessageInformations PublishForceRetryAttemptNumber(Channel channel, T message, int attemptNumber)
-        {
-            return Consumer.ForceRetryStrategy(channel, message, attemptNumber);
-        }
+    public Task<MessageInformations> PublishForceRetryAttemptNumberAsync(Channel channel, T message, int attemptNumber)
+    {
+        return Consumer.ForceRetryStrategyAsync(channel, message, attemptNumber);
     }
 }

--- a/src/MerQure.Tools/Buses/Consumer.cs
+++ b/src/MerQure.Tools/Buses/Consumer.cs
@@ -4,58 +4,61 @@ using MerQure.Tools.Messages;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace MerQure.Tools.Buses
+namespace MerQure.Tools.Buses;
+
+public class Consumer<T> where T : IDelivered
 {
-    public class Consumer<T> where T : IDelivered
+    private readonly ConsumerProvider _consumerProvider;
+    public Dictionary<string, RetryInformations> RetryInformations { get; } = new Dictionary<string, RetryInformations>();
+
+    public Consumer(IMessagingService messagingService)
     {
-        private readonly ConsumerProvider _consumerProvider;
-        public Dictionary<string, RetryInformations> RetryInformations { get; } = new Dictionary<string, RetryInformations>();
+        _consumerProvider = new ConsumerProvider(messagingService);
+    }
 
-        public Consumer(IMessagingService messagingService)
+    public async Task ConsumeAsync(Channel channel, EventHandler<T> callback)
+    {
+        var consumer = await _consumerProvider.GetAsync(channel);
+        await consumer.ConsumeAsync((_, messagingEvent) =>
         {
-            _consumerProvider = new ConsumerProvider(messagingService);
-        }
+            OnMessageReceived(callback, messagingEvent);
+        });
+    }
 
-        public void Consume(Channel channel, EventHandler<T> callback)
-        {
-            _consumerProvider.Get(channel).Consume((object sender, IMessagingEvent messagingEvent) =>
-            {
-                OnMessageReceived(callback, messagingEvent);
-            });
-        }
+    public async Task AcknowlegdeDeliveredMessageAsync(Channel channel, IDelivered deliveredMessage)
+    {
+        deliveredMessage.DeliveryTag = DecodeDeliveryTag(deliveredMessage.DeliveryTag);
+        var consumer = await _consumerProvider.GetAsync(channel);
+        await consumer.AcknowlegdeDeliveredMessageAsync(deliveredMessage);
+        RetryInformations.Remove(deliveredMessage.DeliveryTag);
+    }
 
-        public void AcknowlegdeDeliveredMessage(Channel channel, IDelivered deliveredMessage)
-        {
-            deliveredMessage.DeliveryTag = DecodeDeliveryTag(deliveredMessage.DeliveryTag);
-            _consumerProvider.Get(channel).AcknowlegdeDeliveredMessage(deliveredMessage);
-            RetryInformations.Remove(deliveredMessage.DeliveryTag);
-        }
+    public async Task RejectDeliveredMessageAsync(Channel channel, IDelivered deliveredMessage)
+    {
+        deliveredMessage.DeliveryTag = DecodeDeliveryTag(deliveredMessage.DeliveryTag);
+        var consumer = await _consumerProvider.GetAsync(channel);
+        await consumer.RejectDeliveredMessageAsync(deliveredMessage);
+        RetryInformations.Remove(deliveredMessage.DeliveryTag);
+    }
 
-        public void RejectDeliveredMessage(Channel channel, IDelivered deliveredMessage)
-        {
-            deliveredMessage.DeliveryTag = DecodeDeliveryTag(deliveredMessage.DeliveryTag);
-            _consumerProvider.Get(channel).RejectDeliveredMessage(deliveredMessage);
-            RetryInformations.Remove(deliveredMessage.DeliveryTag);
-        }
+    public void OnMessageReceived(EventHandler<T> callback, IMessagingEvent messagingEvent)
+    {
+        RetryMessage<T> retryMessage = JsonConvert.DeserializeObject<RetryMessage<T>>(messagingEvent.Message.GetBody());
+        retryMessage.OriginalMessage.DeliveryTag = EncodeDeliveryTag(messagingEvent.DeliveryTag);
+        RetryInformations.Add(retryMessage.OriginalMessage.DeliveryTag, retryMessage.RetryInformations);
 
-        public void OnMessageReceived(EventHandler<T> callback, IMessagingEvent messagingEvent)
-        {
-            RetryMessage<T> retryMessage = JsonConvert.DeserializeObject<RetryMessage<T>>(messagingEvent.Message.GetBody());
-            retryMessage.OriginalMessage.DeliveryTag = EncodeDeliveryTag(messagingEvent.DeliveryTag);
-            RetryInformations.Add(retryMessage.OriginalMessage.DeliveryTag, retryMessage.RetryInformations);
+        callback(this, retryMessage.OriginalMessage);
+    }
 
-            callback(this, retryMessage.OriginalMessage);
-        }
+    private static string EncodeDeliveryTag(string deliveryTag) //TODO CLEAN !! this is just a fast fix ...
+    {
+        return $"{deliveryTag}_{Guid.NewGuid().ToString()}";
+    }
 
-        private static string EncodeDeliveryTag(string deliveryTag) //TODO CLEAN !! this is just a fast fix ...
-        {
-            return $"{deliveryTag}_{Guid.NewGuid().ToString()}";
-        }
-
-        private static string DecodeDeliveryTag(string deliveryTag) //TODO CLEAN !! this is just a fast fix
-        {
-            return deliveryTag.Split('_')[0]; 
-        }
+    private static string DecodeDeliveryTag(string deliveryTag) //TODO CLEAN !! this is just a fast fix
+    {
+        return deliveryTag.Split('_')[0];
     }
 }

--- a/src/MerQure.Tools/Buses/IBus.cs
+++ b/src/MerQure.Tools/Buses/IBus.cs
@@ -2,18 +2,18 @@
 using MerQure.Tools.Configurations;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace MerQure.Tools.Buses
+namespace MerQure.Tools.Buses;
+
+public interface IBus<T> where T : IDelivered
 {
-	public interface IBus<T> where T : IDelivered
-    {
-        void Publish(Channel channel, T message, bool applyDeliveryDeplay = false);
-        void PublishWithTransaction(Channel channel, IEnumerable<T> messages, bool applyDeliveryDeplay = false);
-        MessageInformations PublishForceRetryAttemptNumber(Channel channel, T message, int attemptNumber);
-        void OnMessageReceived(Channel channel, EventHandler<T> callback);
-        MessageInformations ApplyRetryStrategy(Channel channel, T deliveredMessage);
-        void AcknowlegdeDeliveredMessage(Channel channel, T deliveredMessage);
-        void RejectDeliveredMessage(Channel channel, T deliveredMessage);
-        void SendDeliveredMessageToErrorBus(Channel channel, T deliveredMessage);
-    }
+    Task PublishAsync(Channel channel, T message, bool applyDeliveryDeplay = false);
+    Task PublishWithTransactionAsync(Channel channel, IEnumerable<T> messages, bool applyDeliveryDeplay = false);
+    Task<MessageInformations> PublishForceRetryAttemptNumberAsync(Channel channel, T message, int attemptNumber);
+    Task OnMessageReceivedAsync(Channel channel, EventHandler<T> callback);
+    Task<MessageInformations> ApplyRetryStrategyAsync(Channel channel, T deliveredMessage);
+    Task AcknowlegdeDeliveredMessageAsync(Channel channel, T deliveredMessage);
+    Task RejectDeliveredMessageAsync(Channel channel, T deliveredMessage);
+    Task SendDeliveredMessageToErrorBusAsync(Channel channel, T deliveredMessage);
 }

--- a/src/MerQure.Tools/IRetryBusService.cs
+++ b/src/MerQure.Tools/IRetryBusService.cs
@@ -1,11 +1,11 @@
 ﻿using MerQure.Messages;
 using MerQure.Tools.Buses;
 using MerQure.Tools.Configurations;
+using System.Threading.Tasks;
 
-namespace MerQure.Tools
+namespace MerQure.Tools;
+
+public interface IRetryBusService
 {
-    public interface IRetryBusService
-    {
-        IBus<T> CreateNewBus<T>(RetryStrategyConfiguration configuration, bool isQuorum) where T : IDelivered;
-    }
+    Task<IBus<T>> CreateNewBusAsync<T>(RetryStrategyConfiguration configuration, bool isQuorum) where T : IDelivered;
 }

--- a/src/MerQure/Clients/IConsumer.cs
+++ b/src/MerQure/Clients/IConsumer.cs
@@ -1,12 +1,14 @@
 ﻿using MerQure.Messages;
+using RabbitMQ.Client.Events;
 using System;
+using System.Threading.Tasks;
 
 namespace MerQure
 {
     /// <summary>
     /// Consumer interface. Used to receive messages from a queue by subscription.
     /// </summary>
-    public interface IConsumer : IDisposable
+    public interface IConsumer : IAsyncDisposable
     {
         /// <summary>
         /// name of the queue subscribed by the consumer
@@ -17,7 +19,7 @@ namespace MerQure
         /// Start listening on the queue
         /// </summary>
         /// <param name="onMessageReceived">Handler called each time a message arrives for this consumer.</param>
-        void Consume(EventHandler<IMessagingEvent> onMessageReceived);
+        Task ConsumeAsync(EventHandler<IMessagingEvent> onMessageReceived);
 
         /// <summary>
         /// Indicates if the Consumer is registred on the queue and waiting for messages
@@ -28,18 +30,18 @@ namespace MerQure
         /// Unregister Consumer from the queue
         /// </summary>
         /// <param name="onConsumerStopped">Handler called when queu has unregistered the consumer</param>
-        void StopConsuming(EventHandler onConsumerStopped);
-        
+        Task StopConsuming(AsyncEventHandler<ConsumerEventArgs> onConsumerStopped);
+
         /// <summary>
         /// Acknowledge a delivered message.
         /// </summary>
         /// <param name="deliveredMessage">delivered message</param>
-        void AcknowlegdeDeliveredMessage(IDelivered deliveredMessage);
-        
+        ValueTask AcknowlegdeDeliveredMessageAsync(IDelivered deliveredMessage);
+
         /// <summary>
         /// Reject a delivered message.
         /// </summary>
         /// <param name="deliveredMessage">delivered message</param>
-        void RejectDeliveredMessage(IDelivered deliveredMessage);
+        ValueTask RejectDeliveredMessageAsync(IDelivered deliveredMessage);
     }
 }

--- a/src/MerQure/Clients/IPublisher.cs
+++ b/src/MerQure/Clients/IPublisher.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MerQure
 {
     /// <summary>
     /// Publisher interface. Used to publish messages on an exchange.
     /// </summary>
-    public interface IPublisher : IDisposable
+    public interface IPublisher : IAsyncDisposable
     {
         /// <summary>
         /// Exchange where publish messages
@@ -17,28 +18,28 @@ namespace MerQure
         /// Publishes a message
         /// </summary>
         /// <param name="message"></param>
-        void Publish(IMessage message);
+        Task PublishAsync(IMessage message);
 
         /// <summary>
         /// Publishes a message with broker confirmation.
-        /// Waits until all messages published since the last call have been confirmed. Default timeout is 10000 milliseconds. 
+        /// Waits until all messages published since the last call have been confirmed. Default timeout is 10000 milliseconds.
         /// Set the publisherAcknowledgementsTimeoutInMilliseconds attribute in RabbitMQ.config to change it.
         /// if PublisherAcknowledgements is not activated an exception is throws
         /// </summary>
         /// <param name="message">message</param>
         /// <see cref="http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/"/>
-        bool PublishWithAcknowledgement(IMessage message);
+        Task PublishWithAcknowledgementAsync(IMessage message);
 
         /// <summary>
         /// Publishes a message with broker confirmation.
-        /// Waits until all messages published since the last call have been confirmed. Default timeout is 10000 milliseconds. 
+        /// Waits until all messages published since the last call have been confirmed. Default timeout is 10000 milliseconds.
         /// Set the publisherAcknowledgementsTimeoutInMilliseconds attribute in RabbitMQ.config to change it.
         /// if PublisherAcknowledgements is not activated an exception is throws
         /// </summary>
         /// <param name="queueName">queue name</param>
         /// <param name="message">message</param>
         /// <see cref="http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/"/>
-        bool PublishWithAcknowledgement(string queueName, string message);
+        Task PublishWithAcknowledgementAsync(string queueName, string message);
 
         /// <summary>
         /// Publishes multiple messages.
@@ -47,6 +48,6 @@ namespace MerQure
         /// </summary>
         /// <param name="queueName">queue name</param>
         /// <param name="messages">messages</param>
-        void PublishWithTransaction(string queueName, IEnumerable<string> messages);
+        Task PublishWithTransactionAsync(string queueName, IEnumerable<string> messages);
     }
 }

--- a/src/MerQure/IMessagingService.cs
+++ b/src/MerQure/IMessagingService.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MerQure
 {
     /// <summary>
-    /// This service expose all clients necessary to used basic functionnalities of a Message Broker 
+    /// This service expose all clients necessary to used basic functionnalities of a Message Broker
     /// </summary>
     public interface IMessagingService
     {
@@ -11,14 +12,14 @@ namespace MerQure
         /// Declare an Exchange (if it doesn't exists)
         /// </summary>
         /// <param name="exchangeName"></param>
-        void DeclareExchange(string exchangeName);
+        Task DeclareExchangeAsync(string exchangeName);
 
         /// <summary>
         /// Declare an Exchange (if it doesn't exists)
         /// </summary>
         /// <param name="exchangeName"></param>
         /// <param name="exchangeType">fanout, direct, topic, headers</param>
-        void DeclareExchange(string exchangeName, string exchangeType);
+        Task DeclareExchangeAsync(string exchangeName, string exchangeType);
 
         /// <summary>
         /// Declare a queue with dead letter policy
@@ -29,9 +30,9 @@ namespace MerQure
         /// <param name="deadLetterRoutingKey"></param>
         /// <param name="isQuorum">Whether created queue should be quorum (when true, quorum arguments will be added to arguments used for queue creation)</param>
         /// <see cref="https://www.rabbitmq.com/dlx.html"/>
-        string DeclareQueueWithDeadLetterPolicy(string queueName, string deadLetterExchange, int messageTimeToLive, string deadLetterRoutingKey, bool isQuorum);
+        Task<string> DeclareQueueWithDeadLetterPolicyAsync(string queueName, string deadLetterExchange, int messageTimeToLive, string deadLetterRoutingKey, bool isQuorum);
 
-        string DeclareQueue(string queueName, byte maxPriority, bool isQuorum);
+        Task<string> DeclareQueueAsync(string queueName, byte maxPriority, bool isQuorum);
 
         /// <summary>
         /// Declare a queue (if it doesn't exists) with specific arguments
@@ -39,14 +40,14 @@ namespace MerQure
         /// <param name="queueName"></param>
         /// <param name="queueArgs">Queue's arguments</param>
         /// <param name="isQuorum">Whether created queue should be quorum (when true, quorum arguments will be added to arguments used for queue creation)</param>
-        string DeclareQueue(string queueName, Dictionary<string, object> queueArgs, bool isQuorum);
+        Task<string> DeclareQueueAsync(string queueName, Dictionary<string, object> queueArgs, bool isQuorum);
 
         /// <summary>
         /// Declare a queue (if it doesn't exists)
         /// </summary>
         /// <param name="queueName"></param>
         /// <param name="isQuorum">Whether created queue should be quorum (when true, quorum arguments will be added to arguments used for queue creation)</param>
-        string DeclareQueue(string queueName, bool isQuorum);
+        Task<string> DeclareQueueAsync(string queueName, bool isQuorum);
 
         /// <summary>
         /// Declare an Binding (if it doesn't exists)
@@ -55,7 +56,7 @@ namespace MerQure
         /// <param name="exchangeName"></param>
         /// <param name="queueName"></param>
         /// <param name="routingKey"></param>
-        void DeclareBinding(string exchangeName, string queueName, string routingKey);
+        Task DeclareBindingAsync(string exchangeName, string queueName, string routingKey);
         /// <summary>
         /// Declare an Binding (if it doesn't exists)
         /// A Binding is the link between an Exchange and a Queue
@@ -64,7 +65,7 @@ namespace MerQure
         /// <param name="queueName"></param>
         /// <param name="routingKey"></param>
         /// <param name="headerBindings"></param>
-        void DeclareBinding(string exchangeName, string queueName, string routingKey, Dictionary<string, object> headerBindings);
+        Task DeclareBindingAsync(string exchangeName, string queueName, string routingKey, Dictionary<string, object> headerBindings);
 
         /// <summary>
         /// Cancel an Binding
@@ -72,26 +73,26 @@ namespace MerQure
         /// <param name="exchangeName"></param>
         /// <param name="queueName"></param>
         /// <param name="routingKey"></param>
-        void CancelBinding(string exchangeName, string queueName, string routingKey);
+        Task CancelBindingAsync(string exchangeName, string queueName, string routingKey);
 
         /// <summary>
         /// Get the publisher, used to declare exchanges et publish messages on it.
         /// </summary>
         /// <param name="exchangeName"></param>
-        IPublisher GetPublisher(string exchangeName);
+        Task<IPublisher> GetPublisherAsync(string exchangeName);
 
         /// <summary>
         /// Get the publisher, used to declare exchanges et publish messages on it.
         /// </summary>
         /// <param name="exchangeName"></param>
         /// <param name"enablePublisherAcknowledgements">required to use publish with acknowledgements</param>
-        IPublisher GetPublisher(string exchangeName, bool enablePublisherAcknowledgements);
+        Task<IPublisher> GetPublisherAsync(string exchangeName, bool enablePublisherAcknowledgements);
 
         /// <summary>
         /// Get the consumer, used to receive messages of a queue
         /// </summary>
         /// <param name="queueName"></param>
-        IConsumer GetConsumer(string queueName);
+        Task<IConsumer> GetConsumerAsync(string queueName);
 
         /// <summary>
         /// Get the consumer, used to receive messages of a queue
@@ -99,6 +100,6 @@ namespace MerQure
         /// <param name="queueName"></param>
         /// <param name="prefetchCount">maximum number of messages that the server will deliver, 0 if unlimited</param>
         /// <returns></returns>
-        IConsumer GetConsumer(string queueName, ushort prefetchCount);
+        Task<IConsumer> GetConsumerAsync(string queueName, ushort prefetchCount);
     }
 }

--- a/src/MerQure/MerQure.csproj
+++ b/src/MerQure/MerQure.csproj
@@ -4,4 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
+  </ItemGroup>
+
 </Project>

--- a/tests/MerQure.RbMQ.Tests/MerQure.RbMQ.Tests.csproj
+++ b/tests/MerQure.RbMQ.Tests/MerQure.RbMQ.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
 	<PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/MerQure.RbMQ.Tests/MessagingServiceTests.cs
+++ b/tests/MerQure.RbMQ.Tests/MessagingServiceTests.cs
@@ -2,55 +2,54 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace MerQure.RbMQ.Tests
+namespace MerQure.RbMQ.Tests;
+
+public class MessagingServiceTests
 {
-    public class MessagingServiceTests
+    [Fact]
+    public void DeclareExchangeFailWithEmptyName()
     {
-        [Fact]
-        public void DeclareExchangeFailWithEmptyName()
+        var messagingService = new MessagingService(null,null);
+
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareExchangeAsync(null));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareExchangeAsync("    "));
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public void DeclareQueueFailWithEmptyName(bool isQuorum)
+    {
+        var messagingService = new MessagingService(null, null);
+
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareQueueAsync(null, isQuorum: isQuorum));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareQueueAsync("    ", isQuorum: isQuorum));
+    }
+    public static IEnumerable<object[]> IsQuorumPossibleValues =>
+        new List<object[]>
         {
-            var messagingService = new MessagingService(null,null);
+            new object[] { true },
+            new object[] { false }
+        };
 
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareExchange(null));
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareExchange("    "));
-        }
+    [Fact]
+    public void DeclareBindingAsyncFailWithEmptyParameters()
+    {
+        var messagingService = new MessagingService(null, null);
 
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void DeclareQueueFailWithEmptyName(bool isQuorum)
-        {
-            var messagingService = new MessagingService(null, null);
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareBindingAsync(null, "queue", "routing"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareBindingAsync("exhange", null, "routing"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareBindingAsync("", "queue", "routing"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareBindingAsync("exhange", "", "routing"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.DeclareBindingAsync("exhange", "queue", null));
+    }
 
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareQueue(null, isQuorum: isQuorum));
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareQueue("    ", isQuorum: isQuorum));
-        }
-        public static IEnumerable<object[]> IsQuorumPossibleValues =>
-            new List<object[]>
-            {
-                new object[] { true },
-                new object[] { false }
-            };
+    [Fact]
+    public void CancelBindingFailWithEmptyParameters()
+    {
+        var messagingService = new MessagingService(null, null);
 
-        [Fact]
-        public void DeclareBindingFailWithEmptyParameters()
-        {
-            var messagingService = new MessagingService(null, null);
-
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding(null, "queue", "routing"));
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("exhange", null, "routing"));
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("", "queue", "routing"));
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("exhange", "", "routing"));
-            Assert.Throws<ArgumentNullException>(() => messagingService.DeclareBinding("exhange", "queue", null));
-        }
-
-        [Fact]
-        public void CancelBindingFailWithEmptyParameters()
-        {
-            var messagingService = new MessagingService(null, null);
-
-            Assert.Throws<ArgumentNullException>(() => messagingService.CancelBinding(null, "queue", "routing"));
-            Assert.Throws<ArgumentNullException>(() => messagingService.CancelBinding("exhange", null, "routing"));
-            Assert.Throws<ArgumentNullException>(() => messagingService.CancelBinding("exhange", "queue", null));
-        }
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.CancelBindingAsync(null, "queue", "routing"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.CancelBindingAsync("exhange", null, "routing"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => messagingService.CancelBindingAsync("exhange", "queue", null));
     }
 }

--- a/tests/MerQure.Tools.Tests/Buses/ConsumerTests.cs
+++ b/tests/MerQure.Tools.Tests/Buses/ConsumerTests.cs
@@ -4,132 +4,132 @@ using MerQure.Tools.Messages;
 using Moq;
 using Newtonsoft.Json;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
-namespace MerQure.Tools.Tests.Buses
+namespace MerQure.Tools.Tests.Buses;
+
+public class ConsumerTests : IDisposable
 {
-    public class ConsumerTests : IDisposable
+    private Mock<IConsumer> _mockMerQureConsumer;
+    private Mock<IMessagingService> _mockMessagingService;
+
+    private Consumer<TestMessage> _consumer;
+    public ConsumerTests()
     {
-        private Mock<IConsumer> _mockMerQureConsumer;
-        private Mock<IMessagingService> _mockMessagingService;
-
-        private Consumer<TestMessage> _consumer;
-        public ConsumerTests()
+        _mockMerQureConsumer = new Mock<IConsumer>();
+        _mockMerQureConsumer.Setup(m => m.ConsumeAsync(It.IsAny<EventHandler<IMessagingEvent>>())).Callback((EventHandler<IMessagingEvent> action) =>
         {
-            _mockMerQureConsumer = new Mock<IConsumer>();
-            _mockMerQureConsumer.Setup(m => m.Consume(It.IsAny<EventHandler<IMessagingEvent>>())).Callback((EventHandler<IMessagingEvent> action) =>
-            {
-                action(this, new Mock<IMessagingEvent>().Object);
-            });
+            action(this, new Mock<IMessagingEvent>().Object);
+        });
 
-            _mockMessagingService = new Mock<IMessagingService>();
-            _mockMessagingService.Setup(m => m.GetConsumer(It.IsAny<string>())).Returns(_mockMerQureConsumer.Object);
-            
-            _consumer = new Consumer<TestMessage>(_mockMessagingService.Object);
+        _mockMessagingService = new Mock<IMessagingService>();
+        _mockMessagingService.Setup(m => m.GetConsumerAsync(It.IsAny<string>())).ReturnsAsync(_mockMerQureConsumer.Object);
 
-        }
-
-        public void Dispose()
-        {
-            _mockMerQureConsumer = null;
-            _mockMessagingService = null;
-            _consumer = null;
-        }
-
-        [Fact]
-        public void Consumer_OnMessageReceived_ShouldCallCallbackWithOriginalMessage()
-        {
-            //Arrange
-            RetryMessage<TestMessage> messageInBody = GetFilledRetryMessage(0);
-
-            Mock<IMessagingEvent> mockMessagingEvent = new Mock<IMessagingEvent>();
-            mockMessagingEvent.Setup(p => p.Message.GetBody()).Returns(JsonConvert.SerializeObject(messageInBody));
-
-            bool callbackCalled = false;
-            TestMessage deliveredMessageFromCallback = null; 
-            //Act
-            _consumer.OnMessageReceived((object sender, TestMessage deliveredMessage) => 
-                {
-                    callbackCalled = true;
-                    deliveredMessageFromCallback = deliveredMessage;
-                }
-            , mockMessagingEvent.Object);
-
-            //Assert
-            Assert.True(callbackCalled);
-            Assert.True(_consumer.RetryInformations.ContainsKey(deliveredMessageFromCallback.DeliveryTag));
-        }
-
-        [Fact]
-        public void Consumer_AcknowlegdeDeliveredMessage_ShouldCallMerQureAcknowledgdeDelivredMessage()
-        {
-            //Arrange
-            TestMessage testMessage = TestMessage.GetFilledTestMessage();
-
-            //Act
-            _consumer.AcknowlegdeDeliveredMessage(new Channel(""), testMessage);
-
-            //Assert
-            _mockMerQureConsumer.Verify(m => m.AcknowlegdeDeliveredMessage(testMessage));
-        }
-
-        [Fact]
-        public void Consumer_AcknowlegdeDeliveredMessage_ShouldRemoveMessageFromRetryInformationsList()
-        {
-            //Arrange
-            RetryMessage<TestMessage> retryMessage = GetFilledRetryMessage(0);
-            TestMessage testMessage = retryMessage.OriginalMessage;
-
-            _consumer.RetryInformations.Add(testMessage.DeliveryTag, retryMessage.RetryInformations);
-
-            //Act
-            _consumer.AcknowlegdeDeliveredMessage(new Channel(""), testMessage);
-
-            //Assert
-            Assert.True(!_consumer.RetryInformations.ContainsKey(testMessage.DeliveryTag));
-        }
-
-
-        [Fact]
-        public void Consumer_RejectDeliveredMessage_ShouldCallMerQureRejectDeliveredMessagee()
-        {
-            //Arrange
-            TestMessage testMessage = TestMessage.GetFilledTestMessage();
-
-            //Act
-            _consumer.RejectDeliveredMessage(new Channel(""), testMessage);
-
-            //Assert
-            _mockMerQureConsumer.Verify(m => m.RejectDeliveredMessage(testMessage));
-        }
-
-        [Fact]
-        public void Consumer_RejectDeliveredMessage_ShouldRemoveMessageFromRetryInformationsList()
-        {
-            //Arrange
-            RetryMessage<TestMessage> retryMessage = GetFilledRetryMessage(0);
-            TestMessage testMessage = retryMessage.OriginalMessage;
-
-            _consumer.RetryInformations.Add(testMessage.DeliveryTag, retryMessage.RetryInformations);
-
-            //Act
-            _consumer.RejectDeliveredMessage(new Channel(""), testMessage);
-
-            //Assert
-            Assert.True(!_consumer.RetryInformations.ContainsKey(testMessage.DeliveryTag));
-        }
-
-        private static RetryMessage<TestMessage> GetFilledRetryMessage(int numberOfRetry)
-        {
-            return new RetryMessage<TestMessage>
-            {
-                OriginalMessage = TestMessage.GetFilledTestMessage(),
-                RetryInformations = new RetryInformations
-                {
-                    NumberOfRetry = numberOfRetry
-                }
-            };
-        }
+        _consumer = new Consumer<TestMessage>(_mockMessagingService.Object);
 
     }
+
+    public void Dispose()
+    {
+        _mockMerQureConsumer = null;
+        _mockMessagingService = null;
+        _consumer = null;
+    }
+
+    [Fact]
+    public void Consumer_OnMessageReceived_ShouldCallCallbackWithOriginalMessage()
+    {
+        //Arrange
+        RetryMessage<TestMessage> messageInBody = GetFilledRetryMessage(0);
+
+        Mock<IMessagingEvent> mockMessagingEvent = new Mock<IMessagingEvent>();
+        mockMessagingEvent.Setup(p => p.Message.GetBody()).Returns(JsonConvert.SerializeObject(messageInBody));
+
+        bool callbackCalled = false;
+        TestMessage deliveredMessageFromCallback = null;
+        //Act
+        _consumer.OnMessageReceived((object sender, TestMessage deliveredMessage) =>
+            {
+                callbackCalled = true;
+                deliveredMessageFromCallback = deliveredMessage;
+            }
+            , mockMessagingEvent.Object);
+
+        //Assert
+        Assert.True(callbackCalled);
+        Assert.True(_consumer.RetryInformations.ContainsKey(deliveredMessageFromCallback.DeliveryTag));
+    }
+
+    [Fact]
+    public async Task Consumer_AcknowlegdeDeliveredMessage_ShouldCallMerQureAcknowledgdeDelivredMessage()
+    {
+        //Arrange
+        TestMessage testMessage = TestMessage.GetFilledTestMessage();
+
+        //Act
+        await _consumer.AcknowlegdeDeliveredMessageAsync(new Channel(""), testMessage);
+
+        //Assert
+        _mockMerQureConsumer.Verify(m => m.AcknowlegdeDeliveredMessageAsync(testMessage));
+    }
+
+    [Fact]
+    public async Task Consumer_AcknowlegdeDeliveredMessage_ShouldRemoveMessageFromRetryInformationsList()
+    {
+        //Arrange
+        RetryMessage<TestMessage> retryMessage = GetFilledRetryMessage(0);
+        TestMessage testMessage = retryMessage.OriginalMessage;
+
+        _consumer.RetryInformations.Add(testMessage.DeliveryTag, retryMessage.RetryInformations);
+
+        //Act
+        await _consumer.AcknowlegdeDeliveredMessageAsync(new Channel(""), testMessage);
+
+        //Assert
+        Assert.True(!_consumer.RetryInformations.ContainsKey(testMessage.DeliveryTag));
+    }
+
+
+    [Fact]
+    public async Task Consumer_RejectDeliveredMessage_ShouldCallMerQureRejectDeliveredMessagee()
+    {
+        //Arrange
+        TestMessage testMessage = TestMessage.GetFilledTestMessage();
+
+        //Act
+        await _consumer.RejectDeliveredMessageAsync(new Channel(""), testMessage);
+
+        //Assert
+        _mockMerQureConsumer.Verify(m => m.RejectDeliveredMessageAsync(testMessage));
+    }
+
+    [Fact]
+    public async Task Consumer_RejectDeliveredMessage_ShouldRemoveMessageFromRetryInformationsList()
+    {
+        //Arrange
+        RetryMessage<TestMessage> retryMessage = GetFilledRetryMessage(0);
+        TestMessage testMessage = retryMessage.OriginalMessage;
+
+        _consumer.RetryInformations.Add(testMessage.DeliveryTag, retryMessage.RetryInformations);
+
+        //Act
+        await _consumer.RejectDeliveredMessageAsync(new Channel(""), testMessage);
+
+        //Assert
+        Assert.True(!_consumer.RetryInformations.ContainsKey(testMessage.DeliveryTag));
+    }
+
+    private static RetryMessage<TestMessage> GetFilledRetryMessage(int numberOfRetry)
+    {
+        return new RetryMessage<TestMessage>
+        {
+            OriginalMessage = TestMessage.GetFilledTestMessage(),
+            RetryInformations = new RetryInformations
+            {
+                NumberOfRetry = numberOfRetry
+            }
+        };
+    }
+
 }

--- a/tests/MerQure.Tools.Tests/RetryBusServiceTests.cs
+++ b/tests/MerQure.Tools.Tests/RetryBusServiceTests.cs
@@ -2,215 +2,215 @@
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
-namespace MerQure.Tools.Tests
+namespace MerQure.Tools.Tests;
+
+public class RetryBusServiceTests : IDisposable
 {
-    public class RetryBusServiceTests : IDisposable
+    private Mock<IMessagingService> _mockMessagingService;
+
+    private RetryBusService _retryBusService;
+
+    private readonly List<string> _channelNames = new List<string>()
     {
-        private Mock<IMessagingService> _mockMessagingService;
+        "testChannel",
+        "testChannel2"
+    };
 
-        private RetryBusService _retryBusService;
+    public RetryBusServiceTests()
+    {
+        _mockMessagingService = new Mock<IMessagingService>();
+        _mockMessagingService
+            .Setup(service => service.DeclareQueueAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((string queueName, bool isQuorum) => isQuorum ? queueName + "-q" : queueName);
 
-        private readonly List<string> _channelNames = new List<string>()
+        _retryBusService = new RetryBusService(_mockMessagingService.Object);
+    }
+
+    public void Dispose()
+    {
+        _mockMessagingService = null;
+        _retryBusService = null;
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public void RetryBusService_CreateNewBus_ShouldThrow_WhenEmptyChannels(bool isQuorum)
+    {
+        //Arrange
+        var retryStrategy = GetMinimalValidConfiguration();
+        retryStrategy.Channels = new List<Channel>();
+
+        //Act && Assert
+        Assert.ThrowsAsync<ArgumentNullException>(() => _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: isQuorum));
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public void RetryBusService_CreateNewBus_ShouldThrow_WhenNullChannels(bool isQuorum)
+    {
+        //Arrange
+        var retryStrategy = GetMinimalValidConfiguration();
+        retryStrategy.Channels = null;
+
+        //Act && Assert
+        Assert.ThrowsAsync<ArgumentNullException>(() => _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: isQuorum));
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public async Task RetryBusService_CreateNewBus_ShouldDeclareTopicExchangeWithBusName(bool isQuorum)
+    {
+        //Arrange
+        var retryStrategy = GetMinimalValidConfiguration();
+
+        //Act
+        await _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: isQuorum);
+
+        //Assert
+        _mockMessagingService.Verify(m => m.DeclareExchangeAsync(retryStrategy.BusName, Constants.ExchangeTypeTopic));
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public async Task RetryBusService_CreateNewBus_ShouldDeclareQueueForeachChannel(bool isQuorum)
+    {
+        //Arrange
+        var retryStrategy = GetMinimalValidConfiguration();
+
+        //Act
+        await _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: isQuorum);
+
+        //Assert
+        _mockMessagingService.Verify(m => m.DeclareQueueAsync(_channelNames[0], isQuorum));
+        _mockMessagingService.Verify(m => m.DeclareQueueAsync(_channelNames[1], isQuorum));
+    }
+
+    [Fact]
+    public async Task RetryBusService_CreateNewBus_ShouldDeclareBindingForeachChannel()
+    {
+        //Arrange
+        var retryStrategy = GetMinimalValidConfiguration();
+
+        //Act
+        await _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: false);
+
+        //Assert
+        _mockMessagingService.Verify(m => m.DeclareBindingAsync(retryStrategy.BusName, $"{_channelNames[0]}", It.IsAny<string>()));
+        _mockMessagingService.Verify(m => m.DeclareBindingAsync(retryStrategy.BusName, $"{_channelNames[1]}", It.IsAny<string>()));
+    }
+
+    [Fact]
+    public async Task RetryBusService_CreateNewBus_quorum_ShouldDeclareBindingForeachChannel()
+    {
+        //Arrange
+        var retryStrategy = GetMinimalValidConfiguration();
+
+        //Act
+        await _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: true);
+
+        //Assert
+        _mockMessagingService.Verify(m => m.DeclareBindingAsync(retryStrategy.BusName, $"{_channelNames[0]}-q", It.IsAny<string>()));
+        _mockMessagingService.Verify(m => m.DeclareBindingAsync(retryStrategy.BusName, $"{_channelNames[1]}-q", It.IsAny<string>()));
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public async Task RetryBusService_CreateNewBus_ShouldDeclareDirectRetryExchangeWithBusName_WhenRetryStrategyContainsDelays(bool isQuorum)
+    {
+        //Arrange
+        var retryStrategy = GetValidConfigurationWithDelay();
+
+        //Act
+        await _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: isQuorum);
+
+        //Assert
+        _mockMessagingService.Verify(m => m.DeclareExchangeAsync(It.Is<string>(exchangeName => exchangeName.Contains(retryStrategy.BusName) && exchangeName.Contains(RetryStrategyConfiguration.RetryExchangeSuffix)),
+            Constants.ExchangeTypeDirect));
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public async Task RetryBusService_CreateNewBus_ShouldDeclareDealLetterQueueForeachChannelAndDelay_WhenRetryStrategyContainsDelays(bool isQuorum)
+    {
+        //Arrange
+        var retryStrategy = GetValidConfigurationWithDelay();
+
+        //Act
+        await _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: isQuorum);
+
+        //Assert
+        foreach(int delay in retryStrategy.DelaysInMsBetweenEachRetry)
         {
-            "testChannel",
-            "testChannel2"
+            _mockMessagingService.Verify(m => m.DeclareQueueWithDeadLetterPolicyAsync(It.Is<string>(queueName => queueName.Contains(_channelNames[0])),
+                retryStrategy.BusName,
+                delay,
+                null,
+                isQuorum));
+            _mockMessagingService.Verify(m => m.DeclareQueueWithDeadLetterPolicyAsync(It.Is<string>(queueName => queueName.Contains(_channelNames[1])),
+                retryStrategy.BusName,
+                delay,
+                null,
+                isQuorum));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(IsQuorumPossibleValues))]
+    public async Task RetryBusService_CreateNewBus_ShouldDeclareDealLetterQueueForeachChannelAndDelay_WhenRetryStrategyContainsPublishingDelay(bool isQuorum)
+    {
+        //Arrange
+        var retryStrategy = GetValidConfigurationWithPublishingDelay();
+
+        //Act
+        await _retryBusService.CreateNewBusAsync<TestMessage>(retryStrategy, isQuorum: isQuorum);
+
+        //Assert
+        _mockMessagingService.Verify(m => m.DeclareQueueWithDeadLetterPolicyAsync(It.Is<string>(queueName => queueName.Contains(_channelNames[0])),
+            retryStrategy.BusName,
+            retryStrategy.DeliveryDelayInMilliseconds,
+            null,
+            isQuorum));
+    }
+
+    public static IEnumerable<object[]> IsQuorumPossibleValues =>
+        new List<object[]>
+        {
+            new object[] { true },
+            new object[] { false }
         };
 
-        public RetryBusServiceTests()
+    private RetryStrategyConfiguration GetMinimalValidConfiguration()
+    {
+        return new RetryStrategyConfiguration()
         {
-            _mockMessagingService = new Mock<IMessagingService>();
-            _mockMessagingService
-                .Setup(service => service.DeclareQueue(It.IsAny<string>(), It.IsAny<bool>()))
-                .Returns((string queueName, bool isQuorum) => isQuorum ? queueName + "-q" : queueName);
-            
-            _retryBusService = new RetryBusService(_mockMessagingService.Object); 
-        }
-
-        public void Dispose()
-        {
-            _mockMessagingService = null;
-            _retryBusService = null;
-        }
-
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void RetryBusService_CreateNewBus_ShouldThrow_WhenEmptyChannels(bool isQuorum)
-        {
-            //Arrange
-            var retryStrategy = GetMinimalValidConfiguration();
-            retryStrategy.Channels = new List<Channel>();
-
-            //Act && Assert
-            Assert.Throws<ArgumentNullException>(() => _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: isQuorum));
-        }
-
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void RetryBusService_CreateNewBus_ShouldThrow_WhenNullChannels(bool isQuorum)
-        {
-            //Arrange
-            var retryStrategy = GetMinimalValidConfiguration();
-            retryStrategy.Channels = null;
-
-            //Act && Assert
-            Assert.Throws<ArgumentNullException>(() => _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: isQuorum));
-        }
-
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void RetryBusService_CreateNewBus_ShouldDeclareTopicExchangeWithBusName(bool isQuorum)
-        {
-            //Arrange
-            var retryStrategy = GetMinimalValidConfiguration();
- 
-            //Act
-            _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: isQuorum);
-
-            //Assert 
-            _mockMessagingService.Verify(m => m.DeclareExchange(retryStrategy.BusName, Constants.ExchangeTypeTopic));
-        }
-
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void RetryBusService_CreateNewBus_ShouldDeclareQueueForeachChannel(bool isQuorum)
-        {
-            //Arrange
-            var retryStrategy = GetMinimalValidConfiguration();
-
-            //Act
-            _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: isQuorum);
-
-            //Assert 
-            _mockMessagingService.Verify(m => m.DeclareQueue(_channelNames[0], isQuorum));
-            _mockMessagingService.Verify(m => m.DeclareQueue(_channelNames[1], isQuorum));
-        }
-
-        [Fact]
-        public void RetryBusService_CreateNewBus_ShouldDeclareBindingForeachChannel()
-        {
-            //Arrange
-            var retryStrategy = GetMinimalValidConfiguration();
-
-            //Act
-            _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: false);
-
-            //Assert 
-            _mockMessagingService.Verify(m => m.DeclareBinding(retryStrategy.BusName, $"{_channelNames[0]}", It.IsAny<string>()));
-            _mockMessagingService.Verify(m => m.DeclareBinding(retryStrategy.BusName, $"{_channelNames[1]}", It.IsAny<string>()));
-        }
-
-        [Fact]
-        public void RetryBusService_CreateNewBus_quorum_ShouldDeclareBindingForeachChannel()
-        {
-            //Arrange
-            var retryStrategy = GetMinimalValidConfiguration();
-
-            //Act
-            _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: true);
-
-            //Assert 
-            _mockMessagingService.Verify(m => m.DeclareBinding(retryStrategy.BusName, $"{_channelNames[0]}-q", It.IsAny<string>()));
-            _mockMessagingService.Verify(m => m.DeclareBinding(retryStrategy.BusName, $"{_channelNames[1]}-q", It.IsAny<string>()));
-        }
-
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void RetryBusService_CreateNewBus_ShouldDeclareDirectRetryExchangeWithBusName_WhenRetryStrategyContainsDelays(bool isQuorum)
-        {
-            //Arrange
-            var retryStrategy = GetValidConfigurationWithDelay();
-
-            //Act
-            _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: isQuorum);
-
-            //Assert 
-            _mockMessagingService.Verify(m => m.DeclareExchange(It.Is<string>(exchangeName => exchangeName.Contains(retryStrategy.BusName) && exchangeName.Contains(RetryStrategyConfiguration.RetryExchangeSuffix)), 
-                                                                Constants.ExchangeTypeDirect));
-        }
-
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void RetryBusService_CreateNewBus_ShouldDeclareDealLetterQueueForeachChannelAndDelay_WhenRetryStrategyContainsDelays(bool isQuorum)
-        {
-            //Arrange
-            var retryStrategy = GetValidConfigurationWithDelay();
-
-            //Act
-            _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: isQuorum);
-
-            //Assert 
-            foreach(int delay in retryStrategy.DelaysInMsBetweenEachRetry)
+            BusName = "busName",
+            Channels = new List<Channel>
             {
-                _mockMessagingService.Verify(m => m.DeclareQueueWithDeadLetterPolicy(It.Is<string>(queueName => queueName.Contains(_channelNames[0])),
-                                                                                     retryStrategy.BusName,
-                                                                                     delay,
-                                                                                     null, 
-                                                                                     isQuorum));
-                _mockMessagingService.Verify(m => m.DeclareQueueWithDeadLetterPolicy(It.Is<string>(queueName => queueName.Contains(_channelNames[1])),
-                                                                                     retryStrategy.BusName,
-                                                                                     delay,
-                                                                                     null,
-                                                                                     isQuorum));
-            }
-        }
+                new Channel(_channelNames[0]),
+                new Channel(_channelNames[1])
+            },
+            DelaysInMsBetweenEachRetry = new List<int>()
+        };
+    }
 
-        [Theory]
-        [MemberData(nameof(IsQuorumPossibleValues))]
-        public void RetryBusService_CreateNewBus_ShouldDeclareDealLetterQueueForeachChannelAndDelay_WhenRetryStrategyContainsPublishingDelay(bool isQuorum)
+    private RetryStrategyConfiguration GetValidConfigurationWithPublishingDelay()
+    {
+        RetryStrategyConfiguration configuration = GetMinimalValidConfiguration();
+        configuration.DeliveryDelayInMilliseconds = 1000;
+        return configuration;
+    }
+
+    private RetryStrategyConfiguration GetValidConfigurationWithDelay()
+    {
+        RetryStrategyConfiguration configuration = GetMinimalValidConfiguration();
+        configuration.DelaysInMsBetweenEachRetry = new List<int>
         {
-            //Arrange
-            var retryStrategy = GetValidConfigurationWithPublishingDelay();
-
-            //Act
-            _retryBusService.CreateNewBus<TestMessage>(retryStrategy, isQuorum: isQuorum);
-
-            //Assert 
-           _mockMessagingService.Verify(m => m.DeclareQueueWithDeadLetterPolicy(It.Is<string>(queueName => queueName.Contains(_channelNames[0])),
-                                                                                     retryStrategy.BusName,
-                                                                                     retryStrategy.DeliveryDelayInMilliseconds,
-                                                                                     null,
-                                                                                     isQuorum));
-        }
-
-        public static IEnumerable<object[]> IsQuorumPossibleValues =>
-            new List<object[]>
-            {
-                new object[] { true },
-                new object[] { false }
-            };
-        
-        private RetryStrategyConfiguration GetMinimalValidConfiguration()
-        {
-            return new RetryStrategyConfiguration()
-            {
-                BusName = "busName",
-                Channels = new List<Channel>
-                {
-                    new Channel(_channelNames[0]),
-                    new Channel(_channelNames[1])
-                },
-                DelaysInMsBetweenEachRetry = new List<int>()
-            };
-        }
-
-        private RetryStrategyConfiguration GetValidConfigurationWithPublishingDelay()
-        {
-            RetryStrategyConfiguration configuration = GetMinimalValidConfiguration();
-            configuration.DeliveryDelayInMilliseconds = 1000;
-            return configuration;
-        }
-
-        private RetryStrategyConfiguration GetValidConfigurationWithDelay()
-        {
-            RetryStrategyConfiguration configuration = GetMinimalValidConfiguration();
-            configuration.DelaysInMsBetweenEachRetry = new List<int>
-            {
-                1000,
-                2000
-            };
-            return configuration;
-        }
+            1000,
+            2000
+        };
+        return configuration;
     }
 }


### PR DESCRIPTION
Tout passe asyc, nécessaire pour les projets utilisant aussi `Lucca.Core.Events` et qui veulent passer en version 8+ (https://github.com/LuccaSA/Lucca.Core.Events/releases/tag/v8.0.0)

https://github.com/rabbitmq/rabbitmq-dotnet-client/discussions/1720
https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/main/v7-MIGRATION.md

⚠️ Cette lib étant proche d'être dépréciée j'ai fait le choix de faire baver RabbitMQ.Client dans le projet MerQure "agnostique" de l'outil. En cause, l'utilisation de `AsyncEventHandler` en signature de `UnregisteredAsync` qui est une implémentation de RabbitMqClient.